### PR TITLE
Adjust names to changes in robot_interfaces

### DIFF
--- a/demos/demo_data_logging.py
+++ b/demos/demo_data_logging.py
@@ -7,9 +7,10 @@ import numpy as np
 from robot_interfaces import finger
 import robot_fingers
 
+
 def main():
 
-    finger_data = finger.Data()
+    finger_data = finger.SingleProcessData()
     finger_backend = robot_fingers.create_fake_finger_backend(finger_data)
     finger_frontend = finger.Frontend(finger_data)
 

--- a/demos/demo_fake_finger.py
+++ b/demos/demo_fake_finger.py
@@ -14,7 +14,8 @@ import robot_fingers
 
 def main():
     # Storage for all observations, actions, etc.
-    finger_data = robot_interfaces.finger.Data()
+    #finger_data = robot_interfaces.finger.MultiProcessData("foo", True)
+    finger_data = robot_interfaces.finger.SingleProcessData()
 
     # The backend sends actions from the data to the robot and writes
     # observations from the robot to the data.  Here we use a backend using the

--- a/demos/demo_real_finger.py
+++ b/demos/demo_real_finger.py
@@ -77,7 +77,6 @@ def demo_position_commands(finger):
         print("Position: %s" % finger.get_observation(t).position)
 
 
-
 def main():
     # Use the default config file from the robot_fingers package
     config_file_path = os.path.join(
@@ -96,7 +95,6 @@ def main():
 
     # Initializes the robot (e.g. performs homing).
     real_finger_backend.initialize()
-
 
     #demo_torque_commands(finger)
     demo_position_commands(finger)

--- a/demos/demo_real_finger.py
+++ b/demos/demo_real_finger.py
@@ -84,7 +84,7 @@ def main():
         rospkg.RosPack().get_path("robot_fingers"), "config", "finger.yml")
 
     # Storage for all observations, actions, etc.
-    finger_data = robot_interfaces.finger.Data()
+    finger_data = robot_interfaces.finger.SingleProcessData()
 
     # The backend sends actions from the data to the robot and writes
     # observations from the robot to the data.

--- a/demos/demo_sparse_position_control.py
+++ b/demos/demo_sparse_position_control.py
@@ -18,7 +18,7 @@ def main():
         rospkg.RosPack().get_path("robot_fingers"), "config", "finger.yml")
 
     # Storage for all observations, actions, etc.
-    finger_data = robot_interfaces.finger.Data()
+    finger_data = robot_interfaces.finger.SingleProcessData()
 
     # The backend sends actions from the data to the robot and writes
     # observations from the robot to the data.

--- a/include/robot_fingers/fake_finger_driver.hpp
+++ b/include/robot_fingers/fake_finger_driver.hpp
@@ -75,7 +75,7 @@ public:
 };
 
 robot_interfaces::FingerTypes::BackendPtr create_fake_finger_backend(
-    robot_interfaces::FingerTypes::DataPtr robot_data)
+    robot_interfaces::FingerTypes::BaseDataPtr robot_data)
 {
     // adjusted values
     constexpr double MAX_ACTION_DURATION_S = 0.03;

--- a/python/robot_fingers/robot.py
+++ b/python/robot_fingers/robot.py
@@ -23,7 +23,7 @@ class Robot:
             config_file_name)
 
         # Storage for all observations, actions, etc.
-        self.robot_data = robot_module.Data()
+        self.robot_data = robot_module.SingleProcessData()
 
         # The backend sends actions from the data to the robot and writes
         # observations from the robot to the data.

--- a/scripts/joint_friction_calibration.py
+++ b/scripts/joint_friction_calibration.py
@@ -160,7 +160,7 @@ def main():
         rospkg.RosPack().get_path("robot_fingers"), "config",
         "onejoint_friction_calibration.yml")
 
-    robot_data = one_joint.Data()
+    robot_data = one_joint.SingleProcessData()
     robot_backend = robot_fingers.create_one_joint_backend(robot_data,
                                                            config_file_path)
     robot_frontend = one_joint.Frontend(robot_data)

--- a/scripts/run_onejoint_tests.py
+++ b/scripts/run_onejoint_tests.py
@@ -256,7 +256,7 @@ def main():
     config_file_path = path.join(
         rospkg.RosPack().get_path("robot_fingers"), "config", "onejoint.yml")
 
-    robot_data = one_joint.Data()
+    robot_data = one_joint.SingleProcessData()
     finger_backend = robot_fingers.create_one_joint_backend(robot_data,
                                                           config_file_path)
     robot = one_joint.Frontend(robot_data)

--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Run TriFinger back-end using multi-process robot data."""
+import os
+
+import rospkg
+
+import robot_interfaces
+import robot_fingers
+
+
+def main():
+    # Use the default config file from the robot_fingers package
+    config_file_path = os.path.join(
+        rospkg.RosPack().get_path("robot_fingers"), "config", "trifinger.yml")
+
+    # Storage for all observations, actions, etc.
+    robot_data = robot_interfaces.trifinger.MultiProcessData("trifinger", True)
+
+    # The backend sends actions from the data to the robot and writes
+    # observations from the robot to the data.
+    real_finger_backend = robot_fingers.create_real_finger_backend(
+        robot_data, config_file_path)
+
+    # Initializes the robot (e.g. performs homing).
+    real_finger_backend.initialize()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -18,11 +18,15 @@ def main():
 
     # The backend sends actions from the data to the robot and writes
     # observations from the robot to the data.
-    real_finger_backend = robot_fingers.create_real_finger_backend(
-        robot_data, config_file_path)
+    backend = robot_fingers.create_trifinger_backend(robot_data,
+                                                     config_file_path)
 
     # Initializes the robot (e.g. performs homing).
-    real_finger_backend.initialize()
+    backend.initialize()
+
+    # FIXME add function to check if back-end is still running
+    while True:
+        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Adjust names to changes in robot_interfaces (`Data` is now `SingleProcessData`).

Note: These are simply the changes that were originally made in https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/50 before the corresponding files were moved.

## How I Tested

- By running a few of the demos without real robot.
- By running the adapted TriFinger demo with the backend in a separate process (using the new `trifinger_backend.py`).


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [ ] https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/50

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
