### PR TITLE
Rename robot_properties_manipulator to _fingers

### DIFF
--- a/scripts/check_finger_position_control_error.py
+++ b/scripts/check_finger_position_control_error.py
@@ -36,7 +36,7 @@ def forward_kinematics(joint_positions):
 
 
 if __name__ == "__main__":
-    urdf_pkg_path = rospkg.RosPack().get_path("robot_properties_manipulator")
+    urdf_pkg_path = rospkg.RosPack().get_path("robot_properties_fingers")
     urdf_path = os.path.join(urdf_pkg_path, "urdf", "finger.urdf")
 
     model = pinocchio.buildModelFromUrdf(urdf_path)


### PR DESCRIPTION

## Description

Rename robot_properties_manipulator to robot_properties_fingers


## How I Tested

Not tested.


## Do not merge before

- [x] Corresponding merge request that actually renames that package.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
