### PR TITLE
Add force sensor to observation of finger robots

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # stop build on first error
-string(APPEND CMAKE_CXX_FLAGS "-Wfatal-errors")
+string(APPEND CMAKE_CXX_FLAGS " -Wfatal-errors")
 
 
 find_package(catkin REQUIRED COMPONENTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ project(robot_fingers)
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
+# stop build on first error
+string(APPEND CMAKE_CXX_FLAGS "-Wfatal-errors")
+
 
 find_package(catkin REQUIRED COMPONENTS
   blmc_robots

--- a/include/robot_fingers/fake_finger_driver.hpp
+++ b/include/robot_fingers/fake_finger_driver.hpp
@@ -19,7 +19,7 @@ class FakeFingerDriver : public robot_interfaces::RobotDriver<
 public:
     typedef robot_interfaces::FingerTypes::Action Action;
     typedef robot_interfaces::FingerTypes::Observation Observation;
-    typedef robot_interfaces::FingerTypes::Vector Vector;
+    typedef robot_interfaces::FingerTypes::Action::Vector Vector;
 
     int data_generating_index_ = 0;
 

--- a/include/robot_fingers/fake_finger_driver.hpp
+++ b/include/robot_fingers/fake_finger_driver.hpp
@@ -12,14 +12,15 @@
 
 namespace robot_fingers
 {
+// TODO rename to include "Mono"
 class FakeFingerDriver : public robot_interfaces::RobotDriver<
-                             robot_interfaces::FingerTypes::Action,
-                             robot_interfaces::FingerTypes::Observation>
+                             robot_interfaces::MonoFingerTypes::Action,
+                             robot_interfaces::MonoFingerTypes::Observation>
 {
 public:
-    typedef robot_interfaces::FingerTypes::Action Action;
-    typedef robot_interfaces::FingerTypes::Observation Observation;
-    typedef robot_interfaces::FingerTypes::Action::Vector Vector;
+    typedef robot_interfaces::MonoFingerTypes::Action Action;
+    typedef robot_interfaces::MonoFingerTypes::Observation Observation;
+    typedef robot_interfaces::MonoFingerTypes::Action::Vector Vector;
 
     int data_generating_index_ = 0;
 
@@ -44,6 +45,8 @@ public:
         observation.torque[0] = data_generating_index_ + 2;
         observation.torque[1] = 2 * data_generating_index_ + 2;
         observation.torque[2] = 3 * data_generating_index_ + 2;
+
+        observation.tip_force[0] = data_generating_index_ / 2;
 
         data_generating_index_++;
 
@@ -74,11 +77,11 @@ public:
     }
 };
 
-robot_interfaces::FingerTypes::BackendPtr create_fake_finger_backend(
-    robot_interfaces::FingerTypes::BaseDataPtr robot_data)
+robot_interfaces::MonoFingerTypes::BackendPtr create_fake_finger_backend(
+    robot_interfaces::MonoFingerTypes::BaseDataPtr robot_data)
 {
     auto robot = std::make_shared<FakeFingerDriver>();
-    auto backend = std::make_shared<robot_interfaces::FingerTypes::Backend>(
+    auto backend = std::make_shared<robot_interfaces::MonoFingerTypes::Backend>(
         robot, robot_data);
     backend->set_max_action_repetitions(-1);
 

--- a/include/robot_fingers/finger_driver.hpp
+++ b/include/robot_fingers/finger_driver.hpp
@@ -11,10 +11,6 @@
 
 namespace robot_fingers
 {
-// FIXME this is defined in multiple places?
-constexpr size_t JOINTS_PER_FINGER = 3;
-constexpr size_t BOARDS_PER_FINGER = 2;
-
 /**
  * @brief Driver for the Finger robots.
  *
@@ -25,17 +21,17 @@ constexpr size_t BOARDS_PER_FINGER = 2;
  */
 template <size_t N_FINGERS>
 class FingerDriver : public blmc_robots::NJointBlmcRobotDriver<
-                              robot_interfaces::FingerObservation<N_FINGERS>,
-                              N_FINGERS * JOINTS_PER_FINGER,
-                              N_FINGERS * BOARDS_PER_FINGER>
+                         robot_interfaces::FingerObservation<N_FINGERS>,
+                         N_FINGERS * robot_interfaces::JOINTS_PER_FINGER,
+                         N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>
 {
 public:
     typedef robot_interfaces::FingerObservation<N_FINGERS> Observation;
 
-    using blmc_robots::NJointBlmcRobotDriver<robot_interfaces::FingerObservation<N_FINGERS>,
-                                N_FINGERS * JOINTS_PER_FINGER,
-                                N_FINGERS *
-                                    BOARDS_PER_FINGER>::NJointBlmcRobotDriver;
+    using blmc_robots::NJointBlmcRobotDriver<
+        robot_interfaces::FingerObservation<N_FINGERS>,
+        N_FINGERS * robot_interfaces::JOINTS_PER_FINGER,
+        N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>::NJointBlmcRobotDriver;
 
     Observation get_latest_observation() override
     {
@@ -49,7 +45,8 @@ public:
         {
             // The force sensor is supposed to be connected to ADC A on the
             // first board of each finger.
-            const size_t board_idx = finger_idx * BOARDS_PER_FINGER;
+            const size_t board_idx =
+                finger_idx * robot_interfaces::BOARDS_PER_FINGER;
 
             auto adc_a_history =
                 this->motor_boards_[board_idx]->get_measurement(

--- a/include/robot_fingers/finger_driver.hpp
+++ b/include/robot_fingers/finger_driver.hpp
@@ -1,0 +1,75 @@
+/**
+ * @file
+ * @brief Driver for the Finger Robots.
+ * @copyright 2020, Max Planck Gesellschaft. All rights reserved.
+ * @license BSD 3-clause
+ */
+#pragma once
+
+#include <blmc_robots/n_joint_blmc_robot_driver.hpp>
+#include <robot_interfaces/finger_types.hpp>
+
+namespace robot_fingers
+{
+// FIXME this is defined in multiple places?
+constexpr size_t JOINTS_PER_FINGER = 3;
+constexpr size_t BOARDS_PER_FINGER = 2;
+
+/**
+ * @brief Driver for the Finger robots.
+ *
+ * This is a generic driver for the CAN-based BLMC Finger Robots.  It works for
+ * both a single finger and a set of multiple fingers.
+ *
+ * @tparam N_FINGERS  Number of fingers on the robot.
+ */
+template <size_t N_FINGERS>
+class FingerDriver : public blmc_robots::NJointBlmcRobotDriver<
+                              robot_interfaces::FingerObservation<N_FINGERS>,
+                              N_FINGERS * JOINTS_PER_FINGER,
+                              N_FINGERS * BOARDS_PER_FINGER>
+{
+public:
+    typedef robot_interfaces::FingerObservation<N_FINGERS> Observation;
+
+    using blmc_robots::NJointBlmcRobotDriver<robot_interfaces::FingerObservation<N_FINGERS>,
+                                N_FINGERS * JOINTS_PER_FINGER,
+                                N_FINGERS *
+                                    BOARDS_PER_FINGER>::NJointBlmcRobotDriver;
+
+    Observation get_latest_observation() override
+    {
+        Observation observation;
+
+        observation.position = this->joint_modules_.get_measured_angles();
+        observation.velocity = this->joint_modules_.get_measured_velocities();
+        observation.torque = this->joint_modules_.get_measured_torques();
+
+        for (size_t finger_idx = 0; finger_idx < N_FINGERS; finger_idx++)
+        {
+            // The force sensor is supposed to be connected to ADC A on the
+            // first board of each finger.
+            const size_t board_idx = finger_idx * BOARDS_PER_FINGER;
+
+            auto adc_a_history =
+                this->motor_boards_[board_idx]->get_measurement(
+                    blmc_drivers::MotorBoardInterface::MeasurementIndex::
+                        analog_1);
+
+            if (adc_a_history->length() == 0)
+            {
+                observation.tip_force[finger_idx] =
+                    std::numeric_limits<double>::quiet_NaN();
+            }
+            else
+            {
+                observation.tip_force[finger_idx] =
+                    adc_a_history->newest_element();
+            }
+        }
+
+        return observation;
+    }
+};
+
+}  // namespace robot_fingers

--- a/include/robot_fingers/n_finger_driver.hpp
+++ b/include/robot_fingers/n_finger_driver.hpp
@@ -20,16 +20,16 @@ namespace robot_fingers
  * @tparam N_FINGERS  Number of fingers on the robot.
  */
 template <size_t N_FINGERS>
-class FingerDriver : public blmc_robots::NJointBlmcRobotDriver<
-                         robot_interfaces::FingerObservation<N_FINGERS>,
+class NFingerDriver : public blmc_robots::NJointBlmcRobotDriver<
+                         robot_interfaces::NFingerObservation<N_FINGERS>,
                          N_FINGERS * robot_interfaces::JOINTS_PER_FINGER,
                          N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>
 {
 public:
-    typedef robot_interfaces::FingerObservation<N_FINGERS> Observation;
+    typedef robot_interfaces::NFingerObservation<N_FINGERS> Observation;
 
     using blmc_robots::NJointBlmcRobotDriver<
-        robot_interfaces::FingerObservation<N_FINGERS>,
+        robot_interfaces::NFingerObservation<N_FINGERS>,
         N_FINGERS * robot_interfaces::JOINTS_PER_FINGER,
         N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>::NJointBlmcRobotDriver;
 

--- a/include/robot_fingers/one_joint_driver.hpp
+++ b/include/robot_fingers/one_joint_driver.hpp
@@ -16,7 +16,7 @@ namespace robot_fingers
  *
  * Driver for a single BLMC joint.  Mostly intended for testing purposes.
  */
-class OneJointDriver : public blmc_robots::NJointBlmcRobotDriver<1, 1>
+class OneJointDriver : public blmc_robots::SimpleNJointBlmcRobotDriver<1, 1>
 {
 public:
     OneJointDriver(const Config &config)
@@ -26,7 +26,7 @@ public:
 
 private:
     OneJointDriver(const MotorBoards &motor_boards, const Config &config)
-        : blmc_robots::NJointBlmcRobotDriver<1, 1>(
+        : blmc_robots::SimpleNJointBlmcRobotDriver<1, 1>(
               motor_boards,
               create_motors(motor_boards),
               {

--- a/include/robot_fingers/real_finger_driver.hpp
+++ b/include/robot_fingers/real_finger_driver.hpp
@@ -14,7 +14,7 @@
 
 namespace robot_fingers
 {
-class RealFingerDriver : public blmc_robots::NJointBlmcRobotDriver<3, 2>
+class RealFingerDriver : public blmc_robots::FingerRobotDriver<1>
 {
 public:
     RealFingerDriver(const Config &config)
@@ -24,7 +24,7 @@ public:
 
 private:
     RealFingerDriver(const MotorBoards &motor_boards, const Config &config)
-        : blmc_robots::NJointBlmcRobotDriver<3, 2>(
+        : blmc_robots::FingerRobotDriver<1>(
               motor_boards,
               create_motors(motor_boards),
               {

--- a/include/robot_fingers/real_finger_driver.hpp
+++ b/include/robot_fingers/real_finger_driver.hpp
@@ -9,12 +9,11 @@
 
 #pragma once
 
-#include <blmc_robots/n_joint_blmc_robot_driver.hpp>
-#include <robot_interfaces/finger_types.hpp>
+#include "finger_driver.hpp"
 
 namespace robot_fingers
 {
-class RealFingerDriver : public blmc_robots::FingerRobotDriver<1>
+class RealFingerDriver : public FingerDriver<1>
 {
 public:
     RealFingerDriver(const Config &config)
@@ -24,7 +23,7 @@ public:
 
 private:
     RealFingerDriver(const MotorBoards &motor_boards, const Config &config)
-        : blmc_robots::FingerRobotDriver<1>(
+        : FingerDriver<1>(
               motor_boards,
               create_motors(motor_boards),
               {

--- a/include/robot_fingers/real_finger_driver.hpp
+++ b/include/robot_fingers/real_finger_driver.hpp
@@ -23,15 +23,14 @@ public:
 
 private:
     RealFingerDriver(const MotorBoards &motor_boards, const Config &config)
-        : FingerDriver<1>(
-              motor_boards,
-              create_motors(motor_boards),
-              {
-                  // MotorParameters
-                  .torque_constant_NmpA = 0.02,
-                  .gear_ratio = 9.0,
-              },
-              config)
+        : FingerDriver<1>(motor_boards,
+                          create_motors(motor_boards),
+                          {
+                              // MotorParameters
+                              .torque_constant_NmpA = 0.02,
+                              .gear_ratio = 9.0,
+                          },
+                          config)
     {
     }
 

--- a/include/robot_fingers/real_finger_driver.hpp
+++ b/include/robot_fingers/real_finger_driver.hpp
@@ -9,11 +9,11 @@
 
 #pragma once
 
-#include "finger_driver.hpp"
+#include "n_finger_driver.hpp"
 
 namespace robot_fingers
 {
-class RealFingerDriver : public FingerDriver<1>
+class RealFingerDriver : public NFingerDriver<1>
 {
 public:
     RealFingerDriver(const Config &config)
@@ -23,7 +23,7 @@ public:
 
 private:
     RealFingerDriver(const MotorBoards &motor_boards, const Config &config)
-        : FingerDriver<1>(motor_boards,
+        : NFingerDriver<1>(motor_boards,
                           create_motors(motor_boards),
                           {
                               // MotorParameters

--- a/include/robot_fingers/trifinger_driver.hpp
+++ b/include/robot_fingers/trifinger_driver.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <blmc_robots/n_joint_blmc_robot_driver.hpp>
-#include <robot_interfaces/trifinger_types.hpp>
 
 namespace robot_fingers
 {

--- a/include/robot_fingers/trifinger_driver.hpp
+++ b/include/robot_fingers/trifinger_driver.hpp
@@ -7,11 +7,11 @@
 
 #pragma once
 
-#include <blmc_robots/n_joint_blmc_robot_driver.hpp>
+#include "finger_driver.hpp"
 
 namespace robot_fingers
 {
-class TriFingerDriver : public blmc_robots::FingerRobotDriver<3>
+class TriFingerDriver : public FingerDriver<3>
 {
 public:
     TriFingerDriver(const Config &config)
@@ -21,7 +21,7 @@ public:
 
 private:
     TriFingerDriver(const MotorBoards &motor_boards, const Config &config)
-        : blmc_robots::FingerRobotDriver<3>(
+        : FingerDriver<3>(
               motor_boards,
               create_motors(motor_boards),
               {

--- a/include/robot_fingers/trifinger_driver.hpp
+++ b/include/robot_fingers/trifinger_driver.hpp
@@ -12,7 +12,7 @@
 
 namespace robot_fingers
 {
-class TriFingerDriver : public blmc_robots::NJointBlmcRobotDriver<9, 6>
+class TriFingerDriver : public blmc_robots::FingerRobotDriver<3>
 {
 public:
     TriFingerDriver(const Config &config)
@@ -22,7 +22,7 @@ public:
 
 private:
     TriFingerDriver(const MotorBoards &motor_boards, const Config &config)
-        : blmc_robots::NJointBlmcRobotDriver<9, 6>(
+        : blmc_robots::FingerRobotDriver<3>(
               motor_boards,
               create_motors(motor_boards),
               {

--- a/include/robot_fingers/trifinger_driver.hpp
+++ b/include/robot_fingers/trifinger_driver.hpp
@@ -7,11 +7,11 @@
 
 #pragma once
 
-#include "finger_driver.hpp"
+#include "n_finger_driver.hpp"
 
 namespace robot_fingers
 {
-class TriFingerDriver : public FingerDriver<3>
+class TriFingerDriver : public NFingerDriver<3>
 {
 public:
     TriFingerDriver(const Config &config)
@@ -21,7 +21,7 @@ public:
 
 private:
     TriFingerDriver(const MotorBoards &motor_boards, const Config &config)
-        : FingerDriver<3>(motor_boards,
+        : NFingerDriver<3>(motor_boards,
                           create_motors(motor_boards),
                           {
                               // MotorParameters

--- a/include/robot_fingers/trifinger_driver.hpp
+++ b/include/robot_fingers/trifinger_driver.hpp
@@ -21,15 +21,14 @@ public:
 
 private:
     TriFingerDriver(const MotorBoards &motor_boards, const Config &config)
-        : FingerDriver<3>(
-              motor_boards,
-              create_motors(motor_boards),
-              {
-                  // MotorParameters
-                  .torque_constant_NmpA = 0.02,
-                  .gear_ratio = 9.0,
-              },
-              config)
+        : FingerDriver<3>(motor_boards,
+                          create_motors(motor_boards),
+                          {
+                              // MotorParameters
+                              .torque_constant_NmpA = 0.02,
+                              .gear_ratio = 9.0,
+                          },
+                          config)
     {
     }
 

--- a/include/robot_fingers/two_joint_driver.hpp
+++ b/include/robot_fingers/two_joint_driver.hpp
@@ -16,7 +16,7 @@ namespace robot_fingers
  *
  * Driver for a double BLMC joint.  Mostly intended for testing purposes.
  */
-class TwoJointDriver : public blmc_robots::NJointBlmcRobotDriver<2, 1>
+class TwoJointDriver : public blmc_robots::SimpleNJointBlmcRobotDriver<2, 1>
 {
 public:
     TwoJointDriver(const Config &config)
@@ -26,7 +26,7 @@ public:
 
 private:
     TwoJointDriver(const MotorBoards &motor_boards, const Config &config)
-        : blmc_robots::NJointBlmcRobotDriver<2, 1>(
+        : blmc_robots::SimpleNJointBlmcRobotDriver<2, 1>(
               motor_boards,
               create_motors(motor_boards),
               {

--- a/scripts/single_finger_test.py
+++ b/scripts/single_finger_test.py
@@ -25,7 +25,7 @@ class CursesGUI:
     def update(self, observation, desired_action, applied_action, status):
         """Update the displayed robot data."""
         # arrange data in arrays
-        observation_data = np.vstack(
+        motor_observation_data = np.vstack(
             [observation.position, observation.velocity, observation.torque]
         ).T
         desired_action_data = np.vstack(
@@ -39,74 +39,84 @@ class CursesGUI:
 
         self.win.erase()
 
-        # status line
-        status_line = " Press 'q' to quit."
-        max_rows, max_cols = self.win.getmaxyx()
-        self.win.insstr(
-            max_rows - 1,
-            0,
-            status_line.ljust(max_cols, " "),
-            curses.A_STANDOUT,
-        )
+        try:
 
-        # header line
-        line = 0
-        self.win.addstr(
-            line, 0, "Single Finger Test Application", curses.A_BOLD
-        )
-        line += 3
+            # status line
+            status_line = " Press 'q' to quit."
+            max_rows, max_cols = self.win.getmaxyx()
+            self.win.insstr(
+                max_rows - 1,
+                0,
+                status_line.ljust(max_cols, " "),
+                curses.A_STANDOUT,
+            )
 
-        # draw the data tables
-        line = self.draw_data_table(
-            line,
-            0,
-            "OBSERVATION",
-            joint_names,
-            ["Position [rad]", "Velocity [rad/s]", "Torque [Nm]"],
-            observation_data,
-        )
-        line += 2
+            # header line
+            line = 0
+            self.win.addstr(
+                line, 0, "Single Finger Test Application", curses.A_BOLD
+            )
+            line += 3
 
-        line = self.draw_data_table(
-            line,
-            0,
-            "DESIRED ACTION",
-            joint_names,
-            ["Torque [Nm]", "Position [rad]"],
-            desired_action_data,
-        )
-        line += 2
+            # draw the data tables
+            line = self.draw_data_table(
+                line,
+                0,
+                "OBSERVATION",
+                joint_names,
+                ["Position [rad]", "Velocity [rad/s]", "Torque [Nm]"],
+                motor_observation_data,
+            )
+            self.win.addstr(
+                line, 0, "Tip Force: {}".format(observation.tip_force)
+            )
+            line += 1
+            line += 2
 
-        line = self.draw_data_table(
-            line,
-            0,
-            "APPLIED ACTION",
-            joint_names,
-            ["Torque [Nm]", "Position [rad]"],
-            applied_action_data,
-        )
-        line += 2
+            line = self.draw_data_table(
+                line,
+                0,
+                "DESIRED ACTION",
+                joint_names,
+                ["Torque [Nm]", "Position [rad]"],
+                desired_action_data,
+            )
+            line += 2
 
-        # status does not fit well in a table, so list values manually here
-        self.win.addstr(line, 0, "STATUS", curses.A_BOLD)
-        line += 1
-        self.win.addstr(line, 0, "━" * 40)
-        line += 1
-        self.win.addstr(
-            line, 0, "Action Repetitions: {}".format(status.action_repetitions)
-        )
-        line += 1
-        self.win.addstr(
-            line, 0, "Error Status: {}".format(status.error_status)
-        )
-        line += 1
-        self.win.addstr(
-            line, 0, "Error Message: {}".format(status.error_message)
-        )
-        line += 1
-        self.win.addstr(line, 0, "━" * 40)
+            line = self.draw_data_table(
+                line,
+                0,
+                "APPLIED ACTION",
+                joint_names,
+                ["Torque [Nm]", "Position [rad]"],
+                applied_action_data,
+            )
+            line += 2
 
-        self.win.refresh()
+            # status does not fit well in a table, so list values manually here
+            self.win.addstr(line, 0, "STATUS", curses.A_BOLD)
+            line += 1
+            self.win.addstr(line, 0, "━" * 40)
+            line += 1
+            self.win.addstr(
+                line, 0, "Action Repetitions: {}".format(status.action_repetitions)
+            )
+            line += 1
+            self.win.addstr(
+                line, 0, "Error Status: {}".format(status.error_status)
+            )
+            line += 1
+            self.win.addstr(
+                line, 0, "Error Message: {}".format(status.error_message)
+            )
+            line += 1
+            self.win.addstr(line, 0, "━" * 40)
+
+            self.win.refresh()
+
+        except curses.error as e:
+            raise RuntimeError(
+                "GUI rendering error.  Try increasing the terminal window.")
 
         # quit if user presses "q"
         c = self.win.getch()


### PR DESCRIPTION
## Description
- Add `FingerDriver` which is based on `blmc_robots::NJointBlmcRobotDriver` and implements `get_latest_observation` that also adds the force sensor readings to the observation.
- Add tip force to the output in single_finger_test.py and also improve the error message in case the terminal window is too small.
- Adjust to name changes in robot_interfaces.


## How I Tested

Running the some demos.  Did not test with an actual sensor connected but general control of the robot still works as expected.


## Merge together with

- [x] https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/66
- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/61

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ ] All new functions/classes are documented and existing documentation is updated according to changes.
- [ ] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
