### PR TITLE
fix: ADC A corresponds to analog_0, not analog_1

### DIFF
--- a/include/robot_fingers/n_finger_driver.hpp
+++ b/include/robot_fingers/n_finger_driver.hpp
@@ -43,15 +43,15 @@ public:
 
         for (size_t finger_idx = 0; finger_idx < N_FINGERS; finger_idx++)
         {
-            // The force sensor is supposed to be connected to ADC A on the
-            // first board of each finger.
+            // The force sensor is supposed to be connected to ADC A
+            // (= analog_0) on the first board of each finger.
             const size_t board_idx =
                 finger_idx * robot_interfaces::BOARDS_PER_FINGER;
 
             auto adc_a_history =
                 this->motor_boards_[board_idx]->get_measurement(
                     blmc_drivers::MotorBoardInterface::MeasurementIndex::
-                        analog_1);
+                        analog_0);
 
             if (adc_a_history->length() == 0)
             {


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Use correct ADC input for force sensor (ADC A corresponds to analog_0, not analog_1).


## How I Tested

Using a slider as ADC input.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
