### PR TITLE
Change Motor Connections according to TriFingerPro and add Demo

### DIFF
--- a/config/single_finger_test.yml
+++ b/config/single_finger_test.yml
@@ -10,5 +10,9 @@ position_control_gains:
     kp: [6, 6, 6]
     kd: [0.03, 0.03, 0.03]
 
+# No position limits in this mode
+hard_position_limits_lower: [-.inf, -.inf, -.inf]
+hard_position_limits_upper: [.inf, .inf, .inf]
+
 home_offset_rad: [0, 0, 0]
 initial_position_rad: [0, 0, 0]

--- a/config/trifingerpro.yml
+++ b/config/trifingerpro.yml
@@ -1,0 +1,58 @@
+can_ports: ["can0", "can1", "can2", "can3", "can4", "can5"]
+max_current_A: 2.0
+has_endstop: true
+calibration:
+    endstop_search_torques_Nm: 
+        - +0.22
+        - +0.22
+        - -0.22
+        - +0.22
+        - +0.22
+        - -0.22
+        - +0.22
+        - +0.22
+        - -0.22
+    position_tolerance_rad: 0.05
+    move_timeout: 2000
+safety_kd:
+    - 0.09
+    - 0.09
+    - 0.05
+    - 0.09
+    - 0.09
+    - 0.05
+    - 0.09
+    - 0.09
+    - 0.05
+position_control_gains:
+    kp: [4, 4, 4, 4, 4, 4, 4, 4, 4]
+    kd: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+
+hard_position_limits_lower: [-5, -5, -5, -5, -5, -5, -5, -5, -5]
+hard_position_limits_upper: [5, 5, 5, 5, 5, 5, 5, 5, 5]
+
+# Set zero-position according to URDF (finger pointing straight down).
+home_offset_rad:
+    - -2.12
+    - -2.44
+    - 2.16
+    - -1.6
+    - -2.16
+    - 2.58
+    - -2.01
+    - -2.14
+    - 2.57
+
+# Set the initial position such that it is still save when the stage is at the
+# highest level.
+initial_position_rad:
+    - 0
+    - 0.9
+    - -1.7
+    - 0
+    - 0.9
+    - -1.7
+    - 0
+    - 0.9
+    - -1.7
+

--- a/demos/demo_trifingerpro.py
+++ b/demos/demo_trifingerpro.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-"""Demo script for the TriFingerEdu robot
+"""Demo script for the TriFingerPro robot
 
-Moves the TriFingerEdu robot with a hard-coded choreography for show-casing and
+Moves the TriFingerPro robot with a hard-coded choreography for show-casing and
 testing.
 """
 import argparse
@@ -22,17 +22,10 @@ def run_choreography(frontend):
                 robot_interfaces.trifinger.Action(position=position))
             frontend.wait_until_time_index(t)
 
-    deg45 = np.pi / 4
-
-    pose_idle = [0, -deg45, -deg45]
-    pose_inward = [0, +deg45, +deg45]
-    pose_side_1 = [-deg45, -deg45, -deg45]
-    pose_side_2 = [0, -deg45, 0]
-    pose_side_3 = [deg45, -deg45, -deg45]
-
     pose_initial = [0, 0.9, -1.7]
     pose_intermediate = [0.75, 1.2, -2.3]
     pose_up = [1.5, 1.5, -3.0]
+    pose_other_side_up = [-1.5, 1.5, -1.7]
 
     last_time_print = 0
 
@@ -41,6 +34,8 @@ def run_choreography(frontend):
         perform_step(pose_initial * 3)
         perform_step(pose_intermediate * 3)
         perform_step(pose_up * 3)
+        perform_step(pose_initial * 3)
+        perform_step(pose_other_side_up * 3)
 
         # print current date/time every hour, so we can roughly see how long it
         # ran in case it crashes during a long-run-test.
@@ -69,7 +64,7 @@ def main():
         # (using the `Robot` helper class).
         robot = robot_fingers.Robot(robot_interfaces.trifinger,
                                     robot_fingers.create_trifinger_backend,
-                                    "trifingeredu.yml")
+                                    "trifingerpro.yml")
         robot.initialize()
         frontend = robot.frontend
 
@@ -79,3 +74,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+

--- a/include/robot_fingers/real_finger_driver.hpp
+++ b/include/robot_fingers/real_finger_driver.hpp
@@ -38,9 +38,9 @@ private:
     {
         // set up motors
         Motors motors;
-        motors[0] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 0);
-        motors[1] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 1);
-        motors[2] = std::make_shared<blmc_drivers::Motor>(motor_boards[1], 0);
+        motors[0] = std::make_shared<blmc_drivers::Motor>(motor_boards[1], 0);
+        motors[1] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 0);
+        motors[2] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 1);
 
         return motors;
     }

--- a/include/robot_fingers/trifinger_driver.hpp
+++ b/include/robot_fingers/trifinger_driver.hpp
@@ -38,17 +38,17 @@ private:
 
         // there are three fingers
         // each finger has three motors and two boards
-        motors[0] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 0);
-        motors[1] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 1);
-        motors[2] = std::make_shared<blmc_drivers::Motor>(motor_boards[1], 0);
+        motors[0] = std::make_shared<blmc_drivers::Motor>(motor_boards[1], 0);
+        motors[1] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 0);
+        motors[2] = std::make_shared<blmc_drivers::Motor>(motor_boards[0], 1);
 
-        motors[3] = std::make_shared<blmc_drivers::Motor>(motor_boards[2], 0);
-        motors[4] = std::make_shared<blmc_drivers::Motor>(motor_boards[2], 1);
-        motors[5] = std::make_shared<blmc_drivers::Motor>(motor_boards[3], 0);
+        motors[3] = std::make_shared<blmc_drivers::Motor>(motor_boards[3], 0);
+        motors[4] = std::make_shared<blmc_drivers::Motor>(motor_boards[2], 0);
+        motors[5] = std::make_shared<blmc_drivers::Motor>(motor_boards[2], 1);
 
-        motors[6] = std::make_shared<blmc_drivers::Motor>(motor_boards[4], 0);
-        motors[7] = std::make_shared<blmc_drivers::Motor>(motor_boards[4], 1);
-        motors[8] = std::make_shared<blmc_drivers::Motor>(motor_boards[5], 0);
+        motors[6] = std::make_shared<blmc_drivers::Motor>(motor_boards[5], 0);
+        motors[7] = std::make_shared<blmc_drivers::Motor>(motor_boards[4], 0);
+        motors[8] = std::make_shared<blmc_drivers::Motor>(motor_boards[4], 1);
 
         return motors;
     }

--- a/scripts/print_position.py
+++ b/scripts/print_position.py
@@ -28,6 +28,11 @@ def main():
             robot_fingers.create_trifinger_backend,
             "trifingeredu.yml",
         ),
+        "trifingerpro": (
+            robot_interfaces.trifinger,
+            robot_fingers.create_trifinger_backend,
+            "trifingerpro.yml",
+        ),
         "onejoint": (
             robot_interfaces.one_joint,
             robot_fingers.create_one_joint_backend,


### PR DESCRIPTION
## Description

- Change the mapping of motor to board/port according to the new TriFingerPro platform.  Other fingers will be reconnected accordingly.
- Add configuration for TriFingerPro.
- Add TriFingerPro to the print position script.
- Add a TriFingerPro demo (based on the one for TriFingerEdu).

## How I Tested

By running test/demo scripts

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
