### PR TITLE
Add module to sample, validate and evaluate goals for a "move cube" task

### DIFF
--- a/python/robot_fingers/tasks/move_cube.py
+++ b/python/robot_fingers/tasks/move_cube.py
@@ -5,17 +5,21 @@ import numpy as np
 from scipy.spatial.transform import Rotation
 
 
-CUBE_WIDTH = 0.065
-ARENA_RADIUS = 0.195
-
-cube_3d_radius = CUBE_WIDTH * np.sqrt(3) / 2
-max_cube_com_distance_to_center = ARENA_RADIUS - cube_3d_radius
-
-min_height = CUBE_WIDTH / 2
-max_height = 0.1  # TODO
+# Number of time steps in one episode
+episode_length = 5000  # TODO set actual value
 
 
-cube_corners = np.array(
+_CUBE_WIDTH = 0.065
+_ARENA_RADIUS = 0.195
+
+_cube_3d_radius = _CUBE_WIDTH * np.sqrt(3) / 2
+_max_cube_com_distance_to_center = _ARENA_RADIUS - _cube_3d_radius
+
+_min_height = _CUBE_WIDTH / 2
+_max_height = 0.1  # TODO
+
+
+_cube_corners = np.array(
     [
         [-1, -1, -1],
         [-1, -1, +1],
@@ -26,7 +30,7 @@ cube_corners = np.array(
         [+1, +1, -1],
         [+1, +1, +1],
     ]
-) * (CUBE_WIDTH / 2)
+) * (_CUBE_WIDTH / 2)
 
 
 def get_cube_corner_positions(position, orientation):
@@ -43,7 +47,7 @@ def get_cube_corner_positions(position, orientation):
     rotation = Rotation.from_quat(orientation)
     translation = np.asarray(position)
 
-    return rotation.apply(cube_corners) + translation
+    return rotation.apply(_cube_corners) + translation
 
 
 def sample_goal(difficulty, current_position=None, current_orientation=None):
@@ -78,7 +82,7 @@ def sample_goal(difficulty, current_position=None, current_orientation=None):
     # that are too easy?
 
     # sample uniform position in circle (https://stackoverflow.com/a/50746409)
-    radius = max_cube_com_distance_to_center * np.sqrt(random.random())
+    radius = _max_cube_com_distance_to_center * np.sqrt(random.random())
     theta = random.uniform(0, 2 * np.pi)
 
     # x,y-position of the cube
@@ -87,10 +91,10 @@ def sample_goal(difficulty, current_position=None, current_orientation=None):
 
     if difficulty == -1 or difficulty == 1:
         # on the ground, random yaw
-        z = CUBE_WIDTH / 2
+        z = _CUBE_WIDTH / 2
     elif difficulty == 2:
         # in the air, random yaw
-        z = random.uniform(min_height, max_height)
+        z = random.uniform(_min_height, _max_height)
     else:
         raise ValueError("Invalid difficulty %d" % difficulty)
 
@@ -121,14 +125,14 @@ def validate_goal(position, orientation):
         return False, "len(position) != 3"
     if len(orientation) != 4:
         return False, "len(orientation) != 4"
-    if np.linalg.norm(position[:2]) > max_cube_com_distance_to_center:
+    if np.linalg.norm(position[:2]) > _max_cube_com_distance_to_center:
         return False, "Position is outside of the arena circle."
-    if position[2] <= min_height:
+    if position[2] <= _min_height:
         return False, "Position is too low."
-    if position[2] >= max_height:
+    if position[2] >= _max_height:
         return False, "Position is too high."
 
-    # even if the CoM is above min_height, a corner could be intersecting with
+    # even if the CoM is above _min_height, a corner could be intersecting with
     # the bottom depending on the orientation
     corners = get_cube_corner_positions(position, orientation)
     min_z = min(z for x, y, z in corners)

--- a/python/robot_fingers/tasks/move_cube.py
+++ b/python/robot_fingers/tasks/move_cube.py
@@ -1,0 +1,126 @@
+import random
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+
+CUBE_WIDTH = 0.065
+ARENA_RADIUS = 0.195
+
+cube_3d_radius = CUBE_WIDTH * np.sqrt(3) / 2
+max_radius = ARENA_RADIUS - cube_3d_radius  # FIXME better name
+
+min_height = CUBE_WIDTH / 2
+max_height = 0.1  # TODO
+
+
+cube_corners = np.array(
+    [
+        [-1, -1, -1],
+        [-1, -1, +1],
+        [-1, +1, -1],
+        [-1, +1, +1],
+        [+1, -1, -1],
+        [+1, -1, +1],
+        [+1, +1, -1],
+        [+1, +1, +1],
+    ]
+) * (CUBE_WIDTH / 2)
+
+
+def get_cube_corner_positions(position, orientation):
+    """Get the positions of the cube's corners with the given pose.
+
+    Args:
+        position: Position (x, y, z) of the cube.
+        orientation: Quaternion (x, y, z, w) with the orientation of the cube.
+
+    Returns:
+        (array, shape=(8, 3)): Positions of the corners of the cube in the
+            given pose.
+    """
+    rotation = Rotation(orientation)
+    translation = np.asarray(position)
+
+    return rotation.apply(cube_corners) + translation
+
+
+def sample_goal(difficulty: int, current_state=None):
+    # TODO depending on difficulty, the current state of the object needs to be
+    # considered (mostly for the orientation)
+
+    # sample uniform position in circle (https://stackoverflow.com/a/50746409)
+    radius = max_radius * np.sqrt(random.random())
+    theta = random.uniform(0, 2 * np.pi)
+
+    # x,y-position of the cube
+    x = radius * np.cos(theta)
+    y = radius * np.sin(theta)
+
+    if difficulty == -1 or difficulty == 1:
+        # on the ground, random yaw
+
+        z = CUBE_WIDTH / 2
+        yaw = random.uniform(0, 2 * np.pi)
+
+        position = np.array((x, y, z))
+        orientation = Rotation.from_euler("z", yaw).as_quat()
+    else:
+        raise ValueError("Invalid difficulty %d" % difficulty)
+
+    return position, orientation
+
+
+def validate_goal(position, orientation):
+    """Validate that the given pose is a valid goal (e.g. no collision)
+
+    Args:
+        position:  Goal position.
+        orientation:  Goal orientation.
+
+    Returns:
+        (bool): True if the given goal pose is within the goal space and does
+            not collide with the static environment.
+    """
+    if len(position) != 3:
+        return False, "len(position) != 3"
+    if len(orientation) != 4:
+        return False, "len(orientation) != 4"
+    if np.linalg.norm(position[:2]) > max_radius:
+        return False, "Position is outside of the arena circle."
+    if position[2] <= min_height:
+        return False, "Position is too low."
+    if position[2] >= max_height:
+        return False, "Position is too high."
+
+    # even if the CoM is above min_height, a corner could be intersecting with
+    # the bottom depending on the orientation
+    corners = get_cube_corner_positions(position, orientation)
+    min_z = min(z for x, y, z in corners)
+    if min_z < 0:
+        return False, "Position is too low."
+
+
+def evaluate_state(
+    goal_position, goal_orientation, actual_position, actual_orientation
+):
+    """Compute cost of a given cube pose.  Less is better.
+
+    Args:
+        goal_position:  Goal position (x, y, z).
+        goal_orientation:  Goal orientation as quaternion (x, y, z, q).
+        actual_position:  Goal position (x, y, z).
+        actual_orientation:  Goal orientation as quaternion (x, y, z, q).
+
+    Returns:
+        Cost of the actual pose w.r.t. to the goal pose.  Lower value means
+        that the actual pose is closer to the goal.  Zero if actual == goal.
+    """
+    # Use DISP distance (max. displacement of the corners)
+    goal_corners = get_cube_corner_positions(goal_position, goal_orientation)
+    actual_corners = get_cube_corner_positions(
+        actual_position, actual_orientation
+    )
+
+    disp = max(np.linalg.norm(goal_corners - actual_corners, axis=1))
+    return disp

--- a/python/robot_fingers/tasks/move_cube.py
+++ b/python/robot_fingers/tasks/move_cube.py
@@ -1,3 +1,4 @@
+"""Functions for sampling, validating and evaluating "move cube" goals."""
 import random
 
 import numpy as np
@@ -8,7 +9,7 @@ CUBE_WIDTH = 0.065
 ARENA_RADIUS = 0.195
 
 cube_3d_radius = CUBE_WIDTH * np.sqrt(3) / 2
-max_radius = ARENA_RADIUS - cube_3d_radius  # FIXME better name
+max_cube_com_distance_to_center = ARENA_RADIUS - cube_3d_radius
 
 min_height = CUBE_WIDTH / 2
 max_height = 0.1  # TODO
@@ -77,7 +78,7 @@ def sample_goal(difficulty, current_position=None, current_orientation=None):
     # that are too easy?
 
     # sample uniform position in circle (https://stackoverflow.com/a/50746409)
-    radius = max_radius * np.sqrt(random.random())
+    radius = max_cube_com_distance_to_center * np.sqrt(random.random())
     theta = random.uniform(0, 2 * np.pi)
 
     # x,y-position of the cube
@@ -120,7 +121,7 @@ def validate_goal(position, orientation):
         return False, "len(position) != 3"
     if len(orientation) != 4:
         return False, "len(orientation) != 4"
-    if np.linalg.norm(position[:2]) > max_radius:
+    if np.linalg.norm(position[:2]) > max_cube_com_distance_to_center:
         return False, "Position is outside of the arena circle."
     if position[2] <= min_height:
         return False, "Position is too low."

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
 d = generate_distutils_setup(
-    packages=["robot_fingers"], package_dir={"": "python"}
+    packages=["robot_fingers", "robot_fingers.tasks"],
+    package_dir={"": "python"}
 )
 
 setup(**d)

--- a/test/test_tasks_move_cube.py
+++ b/test/test_tasks_move_cube.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+import random
+import unittest
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from robot_fingers.tasks import move_cube
+
+
+class TestMoveCube(unittest.TestCase):
+    """Test the functions of the "move cube" task module."""
+
+    def test_get_cube_corner_positions(self):
+        # cube half width
+        chw = move_cube._CUBE_WIDTH / 2
+        # no transformation
+        expected_origin_corners = np.array(
+            [
+                [-chw, -chw, -chw],
+                [-chw, -chw, +chw],
+                [-chw, +chw, -chw],
+                [-chw, +chw, +chw],
+                [+chw, -chw, -chw],
+                [+chw, -chw, +chw],
+                [+chw, +chw, -chw],
+                [+chw, +chw, +chw],
+            ]
+        )
+        origin_corners = move_cube.get_cube_corner_positions(
+            [0, 0, 0], [0, 0, 0, 1]
+        )
+        np.testing.assert_array_almost_equal(
+            expected_origin_corners, origin_corners
+        )
+
+        # only translation
+        expected_translated_corners = np.array(
+            [
+                [-chw + 1, -chw + 2, -chw + 3],
+                [-chw + 1, -chw + 2, +chw + 3],
+                [-chw + 1, +chw + 2, -chw + 3],
+                [-chw + 1, +chw + 2, +chw + 3],
+                [+chw + 1, -chw + 2, -chw + 3],
+                [+chw + 1, -chw + 2, +chw + 3],
+                [+chw + 1, +chw + 2, -chw + 3],
+                [+chw + 1, +chw + 2, +chw + 3],
+            ]
+        )
+        translated = move_cube.get_cube_corner_positions(
+            [1, 2, 3], [0, 0, 0, 1]
+        )
+        np.testing.assert_array_almost_equal(
+            expected_translated_corners, translated
+        )
+
+        # only rotation
+        rot_z90 = Rotation.from_euler("z", 90, degrees=True).as_quat()
+        expected_rotated_corners = np.array(
+            [
+                [+chw, -chw, -chw],
+                [+chw, -chw, +chw],
+                [-chw, -chw, -chw],
+                [-chw, -chw, +chw],
+                [+chw, +chw, -chw],
+                [+chw, +chw, +chw],
+                [-chw, +chw, -chw],
+                [-chw, +chw, +chw],
+            ]
+        )
+        rotated = move_cube.get_cube_corner_positions([0, 0, 0], rot_z90)
+        np.testing.assert_array_almost_equal(expected_rotated_corners, rotated)
+
+        # both rotation and translation
+        expected_both_corners = np.array(
+            [
+                [+chw + 1, -chw + 2, -chw + 3],
+                [+chw + 1, -chw + 2, +chw + 3],
+                [-chw + 1, -chw + 2, -chw + 3],
+                [-chw + 1, -chw + 2, +chw + 3],
+                [+chw + 1, +chw + 2, -chw + 3],
+                [+chw + 1, +chw + 2, +chw + 3],
+                [-chw + 1, +chw + 2, -chw + 3],
+                [-chw + 1, +chw + 2, +chw + 3],
+            ]
+        )
+        both = move_cube.get_cube_corner_positions([1, 2, 3], rot_z90)
+        np.testing.assert_array_almost_equal(expected_both_corners, both)
+
+    def test_sample_goal_difficulty_1_no_initial_pose(self):
+        for i in range(1000):
+            goal_pos, goal_rot = move_cube.sample_goal(difficulty=1)
+            # verify the goal is valid (i.e. within the allowed ranges)
+            try:
+                move_cube.validate_goal(goal_pos, goal_rot)
+            except move_cube.InvalidGoalError as e:
+                self.fail(
+                    msg="Invalid goal: {}  pose is {}, {}".format(
+                        e, e.position, e.orientation
+                    ),
+                )
+
+            # verify the goal satisfies conditions of difficulty 1
+
+            # always on ground
+            self.assertEqual(goal_pos[2], move_cube._CUBE_WIDTH / 2)
+
+            # no rotations around x or y axes
+            rx, ry, rz = Rotation.from_quat(goal_rot).as_euler("xyz")
+            self.assertEqual(rx, 0)
+            self.assertEqual(ry, 0)
+
+    def test_sample_goal_difficulty_1_with_initial_pose(self):
+        for i in range(1000):
+            initial_pos, initial_rot = move_cube.sample_goal(-1)
+
+            goal_pos, goal_rot = move_cube.sample_goal(
+                difficulty=1,
+                current_position=initial_pos,
+                current_orientation=initial_rot,
+            )
+
+            # verify the goal is valid (i.e. within the allowed ranges)
+            try:
+                move_cube.validate_goal(goal_pos, goal_rot)
+            except move_cube.InvalidGoalError as e:
+                self.fail(
+                    msg="Invalid goal: {}  pose is {}, {}".format(
+                        e, e.position, e.orientation
+                    ),
+                )
+
+            # verify the goal satisfies conditions of difficulty 1
+
+            # always on ground
+            self.assertEqual(goal_pos[2], move_cube._CUBE_WIDTH / 2)
+
+            # no rotations around x or y axes
+            expected_rx, expected_ry, expected_rz = Rotation.from_quat(
+                goal_rot
+            ).as_euler("xyz")
+            actual_rx, actual_ry, actual_rz = Rotation.from_quat(
+                goal_rot
+            ).as_euler("xyz")
+            self.assertEqual(actual_rx, expected_rx)
+            self.assertEqual(actual_ry, expected_ry)
+
+    def test_sample_goal_difficulty_2_no_initial_pose(self):
+        for i in range(1000):
+            goal_pos, goal_rot = move_cube.sample_goal(difficulty=2)
+            # verify the goal is valid (i.e. within the allowed ranges)
+            try:
+                move_cube.validate_goal(goal_pos, goal_rot)
+            except move_cube.InvalidGoalError as e:
+                self.fail(
+                    msg="Invalid goal: {}  pose is {}, {}".format(
+                        e, e.position, e.orientation
+                    ),
+                )
+
+            # verify the goal satisfies conditions of difficulty 2
+
+            half_width = move_cube._CUBE_WIDTH / 2
+            # TODO max_height +/- half_width?
+            self.assertLessEqual(goal_pos[2], move_cube._max_height)
+            self.assertGreaterEqual(goal_pos[2], half_width)
+
+            # no rotations around x or y axes
+            rx, ry, rz = Rotation.from_quat(goal_rot).as_euler("xyz")
+            self.assertEqual(rx, 0)
+            self.assertEqual(ry, 0)
+
+    def test_sample_goal_difficulty_2_with_initial_pose(self):
+        for i in range(1000):
+            initial_pos, initial_rot = move_cube.sample_goal(-1)
+
+            goal_pos, goal_rot = move_cube.sample_goal(
+                difficulty=2,
+                current_position=initial_pos,
+                current_orientation=initial_rot,
+            )
+
+            # verify the goal is valid (i.e. within the allowed ranges)
+            try:
+                move_cube.validate_goal(goal_pos, goal_rot)
+            except move_cube.InvalidGoalError as e:
+                self.fail(
+                    msg="Invalid goal: {}  pose is {}, {}".format(
+                        e, e.position, e.orientation
+                    ),
+                )
+
+            # verify the goal satisfies conditions of difficulty 2
+
+            half_width = move_cube._CUBE_WIDTH / 2
+            # TODO max_height +/- half_width?
+            self.assertLessEqual(goal_pos[2], move_cube._max_height)
+            self.assertGreaterEqual(goal_pos[2], half_width)
+
+            # no rotations around x or y axes
+            expected_rx, expected_ry, expected_rz = Rotation.from_quat(
+                goal_rot
+            ).as_euler("xyz")
+            actual_rx, actual_ry, actual_rz = Rotation.from_quat(
+                goal_rot
+            ).as_euler("xyz")
+            self.assertEqual(actual_rx, expected_rx)
+            self.assertEqual(actual_ry, expected_ry)
+
+    def test_evaluate_state(self):
+        p1 = [0, 0, 0]
+        o1 = [0, 0, 0, 1]
+        p2 = [1, 2, 3]
+        o2 = Rotation.from_euler("z", 0.42).as_quat()
+
+        # needs to be zero for exact match
+        cost = move_cube.evaluate_state(p1, o1, p1, o1)
+        self.assertEqual(cost, 0)
+
+        # None-zero if there is translation, rotation or both
+        self.assertNotEqual(move_cube.evaluate_state(p1, o1, p2, o1), 0)
+        self.assertNotEqual(move_cube.evaluate_state(p1, o1, p1, o2), 0)
+        self.assertNotEqual(move_cube.evaluate_state(p1, o1, p2, o2), 0)
+
+    def test_validate_goal(self):
+        half_width = move_cube._CUBE_WIDTH / 2
+        yaw_rotation = Rotation.from_euler("z", 0.42).as_quat()
+        full_rotation = Rotation.from_euler("zxz", [0.42, 0.1, -2.3]).as_quat()
+
+        # test some valid goals
+        try:
+            move_cube.validate_goal([0, 0, half_width], [0, 0, 0, 1])
+        except Exception as e:
+            self.fail("Valid goal was considered invalid because %s" % e)
+
+        try:
+            move_cube.validate_goal([0.05, -0.1, half_width], yaw_rotation)
+        except Exception as e:
+            self.fail("Valid goal was considered invalid because %s" % e)
+
+        try:
+            move_cube.validate_goal([-0.12, 0.0, 0.06], full_rotation)
+        except Exception as e:
+            self.fail("Valid goal was considered invalid because %s" % e)
+
+        # test some invalid goals
+
+        # invalid values
+        with self.assertRaises(ValueError):
+            move_cube.validate_goal([0, 0], [0, 0, 0, 1])
+        with self.assertRaises(ValueError):
+            move_cube.validate_goal([0, 0, 0], [0, 0, 1])
+
+        # invalid positions
+        with self.assertRaises(move_cube.InvalidGoalError):
+            move_cube.validate_goal([0.3, 0, half_width], [0, 0, 0, 1])
+        with self.assertRaises(move_cube.InvalidGoalError):
+            move_cube.validate_goal([0, -0.3, half_width], [0, 0, 0, 1])
+        with self.assertRaises(move_cube.InvalidGoalError):
+            move_cube.validate_goal([0, 0, 0.3], [0, 0, 0, 1])
+        with self.assertRaises(move_cube.InvalidGoalError):
+            move_cube.validate_goal([0, 0, 0], [0, 0, 0, 1])
+        with self.assertRaises(move_cube.InvalidGoalError):
+            move_cube.validate_goal([0, 0, -0.01], [0, 0, 0, 1])
+
+        # valid CoM position but rotation makes it reach out of valid range
+        with self.assertRaises(move_cube.InvalidGoalError):
+            move_cube.validate_goal([0, 0, half_width], full_rotation)
+
+
+if __name__ == "__main__":
+    import rosunit
+
+    rosunit.unitrun(
+        "robot_fingers", "test_tasks_move_cube", TestMoveCube,
+    )


### PR DESCRIPTION
## Description

Add a `tasks` subpackage with one module for the "move cube" task.

The module provides functions for sampling, validating and evaluating goal poses for the cube.  The idea is that for following tasks an equivalent module with the same functions is added.

## Open Questions
- [x] Should we better create a separate package for this (e.g. "finger_tasks")?
- [x] Should there be a minimum distance to the current position when sampling a goal (to avoid very easy goals)?
- [ ] What should be the maximum height?
- [x] Should there be a minimum height for level 2?
- [x] Does the current cost function make sense?

## How I Tested

Not much yet.  I should add unit tests but would first like to see if the intended behaviour is good.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
