### PR TITLE
Tuned pd gains for the fingers on trifingeredu

### DIFF
--- a/config/fingeredu.yml
+++ b/config/fingeredu.yml
@@ -7,8 +7,8 @@ calibration:
     move_timeout: 2000
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:
-    kp: [6, 6, 6]
-    kd: [0.03, 0.03, 0.03]
+    kp: [7, 7, 6.5]
+    kd: [0.01, 0.015, 0.02]
 hard_position_limits_lower: [-2.0, -1.4, -3.2]
 hard_position_limits_upper: [1.6, 1.8, 3.2]
 

--- a/config/fingeredu_0.yml
+++ b/config/fingeredu_0.yml
@@ -7,14 +7,14 @@ calibration:
         - 0.22
         - -0.18
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_timeout: 500
 safety_kd:
     - 0.09
     - 0.09
     - 0.05
 position_control_gains:
-    kp: [5, 5, 5]
-    kd: [0.03, 0.03, 0.03]
+    kp: [7, 7, 6.5]
+    kd: [0.01, 0.015, 0.02]
 
 hard_position_limits_lower:
     - -2.0

--- a/config/fingeredu_120.yml
+++ b/config/fingeredu_120.yml
@@ -7,14 +7,14 @@ calibration:
         - 0.22
         - -0.18
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_timeout: 500
 safety_kd:
     - 0.09
     - 0.09
     - 0.05
 position_control_gains:
-    kp: [5, 5, 5]
-    kd: [0.03, 0.03, 0.03]
+    kp: [7, 7, 6.5]
+    kd: [0.01, 0.015, 0.02]
 
 hard_position_limits_lower:
     - -2.0

--- a/config/fingeredu_240.yml
+++ b/config/fingeredu_240.yml
@@ -7,14 +7,14 @@ calibration:
         - 0.22
         - -0.18
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_timeout: 500
 safety_kd:
     - 0.09
     - 0.09
     - 0.05
 position_control_gains:
-    kp: [5, 5, 5]
-    kd: [0.03, 0.03, 0.03]
+    kp: [7, 7, 6.5]
+    kd: [0.01, 0.015, 0.02]
 
 hard_position_limits_lower:
     - -2.0

--- a/config/trifingeredu.yml
+++ b/config/trifingeredu.yml
@@ -13,7 +13,7 @@ calibration:
         - 0.22
         - -0.18
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_timeout: 500
 safety_kd:
     - 0.09
     - 0.09
@@ -25,8 +25,8 @@ safety_kd:
     - 0.09
     - 0.05
 position_control_gains:
-    kp: [5, 5, 5, 5, 5, 5, 5, 5, 5]
-    kd: [0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03, 0.03]
+    kp: [7, 7, 6.5, 7, 7, 6.5, 7, 7, 6.5]
+    kd: [0.01, 0.015, 0.02, 0.01, 0.015, 0.02, 0.01, 0.015, 0.02]
 
 hard_position_limits_lower:
     - -2.0


### PR DESCRIPTION
## Description

Set the pd gains for the three fingers so as to minimize the joint position errors (~1e-3 now) and also check the tip position error to thus be of the order of a up to 5 mm (though usually lies below 3mm). 


## How I Tested

By running the script check_finger_position_control_error.py 

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
