### PR TITLE
Do not use deprecated versions of "timeindex" methods

### DIFF
--- a/demos/demo_real_finger.py
+++ b/demos/demo_real_finger.py
@@ -71,7 +71,7 @@ def demo_position_commands(finger):
             # executed.
             action = robot_interfaces.finger.Action(position=desired_position)
             t = finger.append_desired_action(action)
-            finger.wait_until_time_index(t)
+            finger.wait_until_timeindex(t)
 
         # print current position from time to time
         print("Position: %s" % finger.get_observation(t).position)

--- a/demos/demo_sparse_position_control.py
+++ b/demos/demo_sparse_position_control.py
@@ -41,7 +41,7 @@ def main():
         # set only the position in the action, torque is zero by default
         action = robot_interfaces.finger.Action(position=desired_position)
         t = finger.append_desired_action(action)
-        finger.wait_until_time_index(t)
+        finger.wait_until_timeindex(t)
 
 
 if __name__ == "__main__":

--- a/demos/demo_trifinger.py
+++ b/demos/demo_trifinger.py
@@ -21,7 +21,7 @@ def run_choreography(frontend):
             t = frontend.append_desired_action(
                 robot_interfaces.trifinger.Action(position=position)
             )
-            frontend.wait_until_time_index(t)
+            frontend.wait_until_timeindex(t)
 
     deg22 = np.pi / 8
     deg45 = np.pi / 4

--- a/demos/demo_trifingeredu.py
+++ b/demos/demo_trifingeredu.py
@@ -20,7 +20,7 @@ def run_choreography(frontend):
         for i in range(1000):
             t = frontend.append_desired_action(
                 robot_interfaces.trifinger.Action(position=position))
-            frontend.wait_until_time_index(t)
+            frontend.wait_until_timeindex(t)
 
     deg45 = np.pi / 4
 

--- a/demos/demo_trifingerpro.py
+++ b/demos/demo_trifingerpro.py
@@ -20,7 +20,7 @@ def run_choreography(frontend):
         for i in range(1000):
             t = frontend.append_desired_action(
                 robot_interfaces.trifinger.Action(position=position))
-            frontend.wait_until_time_index(t)
+            frontend.wait_until_timeindex(t)
 
     pose_initial = [0, 0.9, -1.7]
     pose_intermediate = [0.75, 1.2, -2.3]

--- a/scripts/check_finger_position_control_error.py
+++ b/scripts/check_finger_position_control_error.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
             # executed.
             action = robot_interfaces.finger.Action(position=desired_position)
             t = robot.frontend.append_desired_action(action)
-            robot.frontend.wait_until_time_index(t)
+            robot.frontend.wait_until_timeindex(t)
 
         desired_tip_pos = forward_kinematics(desired_position)
         actual_tip_pos = forward_kinematics(

--- a/scripts/fingeredu_endurance_test.py
+++ b/scripts/fingeredu_endurance_test.py
@@ -39,7 +39,7 @@ def demo_position_commands(finger):
             # executed.
             action = robot_interfaces.finger.Action(position=desired_position)
             t = finger.append_desired_action(action)
-            finger.wait_until_time_index(t)
+            finger.wait_until_timeindex(t)
 
         # print current date/time every hour, so we can roughly see how long it
         # ran in case it crashes during a long-run-test.

--- a/scripts/run_onejoint_tests.py
+++ b/scripts/run_onejoint_tests.py
@@ -47,7 +47,7 @@ def zero_torque_ctrl(robot, duration, print_position=False):
     while step < duration:
         step += 1
         t = robot.append_desired_action(action)
-        robot.wait_until_time_index(t)
+        robot.wait_until_timeindex(t)
         if print_position:
             print(
                 "\rPosition: %10.4f" % robot.get_observation(t).position[0],
@@ -73,12 +73,12 @@ def go_to(robot, goal_position, steps, hold):
     for step in range(steps):
         desired_step_position += stepsize
         t = robot.append_desired_action(Action(position=desired_step_position))
-        robot.wait_until_time_index(t)
+        robot.wait_until_timeindex(t)
 
     action = Action(position=np.ones(N_JOINTS) * goal_position)
     for step in range(hold):
         t = robot.append_desired_action(action)
-        robot.wait_until_time_index(t)
+        robot.wait_until_timeindex(t)
 
 
 def go_to_zero(robot, steps, hold):
@@ -113,7 +113,7 @@ def hit_endstop(robot, desired_torque, hold=0, timeout=5000):
 
     for step in range(hold):
         t = robot.append_desired_action(action)
-        robot.wait_until_time_index(t)
+        robot.wait_until_timeindex(t)
 
 
 def test_if_moves(robot, desired_torque, timeout):
@@ -160,7 +160,7 @@ def validate_position(robot):
 
     for i, sign in enumerate((+1, -1)):
         hit_endstop(robot, sign * desired_torque)
-        t = robot.get_current_time_index()
+        t = robot.get_current_timeindex()
         position[i] = robot.get_observation(t).position
 
     center = (position[0] + position[1]) / 2
@@ -279,7 +279,7 @@ def main():
             go_to(robot, -POSITION_LIMIT, 500, 10)
             hard_direction_change(robot, 2, trq)
 
-            t = robot.get_current_time_index()
+            t = robot.get_current_timeindex()
             if np.any(
                 np.abs(robot.get_observation(t).position) > POSITION_LIMIT
             ):


### PR DESCRIPTION
## Description

The `*_time_index` methods are deprecated and the new `*_timeindex`
variants should be used to be consistent with the C++ API.

## How I Tested

Not explicitly tested.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/70

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
