### PR TITLE
Scripts to record and replay demonstrated trajectories

### DIFF
--- a/python/robot_fingers/__init__.py
+++ b/python/robot_fingers/__init__.py
@@ -1,6 +1,6 @@
-from robot_fingers.robot import Robot, demo_print_position
-
 from robot_fingers.py_real_finger import *
 from robot_fingers.py_trifinger import *
 from robot_fingers.py_one_joint import *
 from robot_fingers.py_two_joint import *
+
+from robot_fingers.robot import Robot, demo_print_position

--- a/scripts/demonstrate_trajectory.py
+++ b/scripts/demonstrate_trajectory.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Record data while the user is manually moving the robot."""
+import argparse
+import curses
+
+import robot_fingers
+
+
+class SimpleCursesGUI:
+    """Wrapper around curses to manage simple generic GUIs.
+
+    A very simple curses interface with a title at the top, a static status
+    line at the bottom and some arbitrary text in between that can be updated.
+    """
+
+    def __init__(self, win, title, status_line=None):
+        """Initialize.
+
+        Args:
+            win: Curses window.
+        """
+        self.win = win
+        self.win.nodelay(True)
+        self.title = title
+        self.status_line = status_line
+
+    def display_error(self, message):
+        """Display error message and wait until user presses a key.
+
+        Args:
+            message:  The error message that is displayed.
+        """
+        self.win.nodelay(False)
+        self.win.clear()
+
+        self.win.addstr(1, 0, "ERROR:", curses.A_BOLD)
+        self.win.addstr(3, 4, message)
+        self.win.addstr(5, 0, "Press any key to exit.")
+        self.win.refresh()
+
+        self.win.getch()
+
+    def update_screen(self, lines):
+        """Update the screen with the given lines of text.
+
+        Args:
+            lines (list):  List of strings.  They are drawn in separate lines.
+        """
+        try:
+            self.win.erase()
+
+            self.win.addstr(0, 0, self.title, curses.A_BOLD)
+
+            # status line
+            if self.status_line:
+                max_rows, max_cols = self.win.getmaxyx()
+                self.win.insstr(
+                    max_rows - 1,
+                    0,
+                    self.status_line.ljust(max_cols, " "),
+                    curses.A_STANDOUT,
+                )
+
+            for i, line in enumerate(lines):
+                self.win.addstr(2 + i, 0, line)
+
+            self.win.refresh()
+        except curses.error as e:
+            raise RuntimeError(
+                "GUI rendering error.  Try increasing the terminal window."
+            )
+
+    def get_pressed_key(self):
+        """Get key pressed by the user."""
+        return self.win.getch()
+
+
+def loop(win, args):
+    title = "Demonstration Recorder"
+    status_line = " q: quit | space: start/stop recording"
+
+    robot = robot_fingers.Robot.create_by_name(args.robot_type)
+    robot.initialize()
+
+    gui = SimpleCursesGUI(win, title, status_line)
+
+    is_recording = False
+    try:
+        while True:
+            t = robot.frontend.append_desired_action(robot.Action())
+            robot.frontend.wait_until_timeindex(t)
+
+            if is_recording:
+                gui.update_screen(["Recording...", "Press [space] to stop."])
+            else:
+                gui.update_screen(["Press [space] to start recording."])
+
+            pressed_key = gui.get_pressed_key()
+            if pressed_key == ord("q"):
+                # quit
+                return
+            elif pressed_key == ord(" "):
+                if is_recording:
+                    robot.logger.stop()
+                else:
+                    robot.logger.start(args.outfile)
+
+                is_recording = not is_recording
+
+    except Exception as e:
+        gui.display_error(str(e))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "robot_type",
+        choices=robot_fingers.Robot.get_supported_robots(),
+        help="Name of the robot.",
+    )
+    parser.add_argument(
+        "outfile", type=str, help="Output file for the recorded data."
+    )
+    args = parser.parse_args()
+
+    curses.wrapper(lambda stdscr: loop(stdscr, args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/print_position.py
+++ b/scripts/print_position.py
@@ -2,54 +2,17 @@
 """Send zero-torque commands to the robot and print joint positions."""
 import argparse
 
-import robot_interfaces
 import robot_fingers
 
 
 def main():
-    robot_type = {
-        "fingerone": (
-            robot_interfaces.finger,
-            robot_fingers.create_real_finger_backend,
-            "finger.yml",
-        ),
-        "trifingerone": (
-            robot_interfaces.trifinger,
-            robot_fingers.create_trifinger_backend,
-            "trifinger.yml",
-        ),
-        "fingeredu": (
-            robot_interfaces.finger,
-            robot_fingers.create_real_finger_backend,
-            "fingeredu.yml",
-        ),
-        "trifingeredu": (
-            robot_interfaces.trifinger,
-            robot_fingers.create_trifinger_backend,
-            "trifingeredu.yml",
-        ),
-        "trifingerpro": (
-            robot_interfaces.trifinger,
-            robot_fingers.create_trifinger_backend,
-            "trifingerpro.yml",
-        ),
-        "onejoint": (
-            robot_interfaces.one_joint,
-            robot_fingers.create_one_joint_backend,
-            "onejoint.yml",
-        ),
-        "twojoint": (
-            robot_interfaces.two_joint,
-            robot_fingers.create_two_joint_backend,
-            "twojoint.yml",
-        ),
-    }
-
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("robot_type", choices=robot_type.keys())
+    parser.add_argument(
+        "robot_type", choices=robot_fingers.Robot.get_supported_robots()
+    )
     args = parser.parse_args()
 
-    robot = robot_fingers.Robot(*robot_type[args.robot_type])
+    robot = robot_fingers.Robot.create_by_name(args.robot_type)
 
     robot.initialize()
     robot_fingers.demo_print_position(robot)

--- a/scripts/replay_trajectory.py
+++ b/scripts/replay_trajectory.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Move the robot on the trajectory of a previously recorded log file."""
+import argparse
+
+import pandas
+
+import robot_fingers
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "robot_type",
+        choices=robot_fingers.Robot.get_supported_robots(),
+        help="Name of the robot.",
+    )
+    parser.add_argument("logfile", type=str, help="Path to the log file.")
+    parser.add_argument(
+        "--speed", "-s", type=float, default=1.0, help="Playback speed."
+    )
+    args = parser.parse_args()
+
+    data = pandas.read_csv(
+        args.logfile, delim_whitespace=True, header=0, low_memory=False
+    )
+
+    # determine number of joints
+    data_keys = []
+    key_pattern = "observation_position_{}"
+    i = 0
+    while key_pattern.format(i) in data:
+        data_keys.append(key_pattern.format(i))
+        i += 1
+
+    # extract the positions from the recorded data
+    positions = data[data_keys].to_numpy()
+    num_positions = len(positions)
+    print("Replay {} positions".format(num_positions))
+
+    # initialize robot
+    robot = robot_fingers.Robot.create_by_name(args.robot_type)
+    robot.initialize()
+
+    # move robot to the recorded positions.  At speed = 1, every position is
+    # executed once (= original speed), at speed < 1, positions are repeated
+    # (slower playback), at speed > 1, some positions are skipped (faster
+    # playback).
+    step = 0
+    while int(step) < num_positions:
+        position = positions[int(step)]
+        step += args.speed
+
+        action = robot.Action(position=position)
+        t = robot.frontend.append_desired_action(action)
+        robot.frontend.wait_until_timeindex(t)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description
- Refactor the creation of a `Robot` instance by name: Move the dictionary with default setups to the `Robot` class to have it in
a central place instead of duplicating it in each script (note: not all scripts are adapted to this yet).
- Add script `demonstrate_trajctories.py` to record demonstrated trajectories.  This simply runs the robot in zero-torque mode and provides an interface to start/stop the RobotLogger with a key press.
- Add script `replay_trajectories.py` to replay the trajectory from the observations of a log file.


## How I Tested

Tested on TriFingerPro.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
