### PR TITLE
Replace move_timeout with move_steps in config files

### DIFF
--- a/config/finger.yml
+++ b/config/finger.yml
@@ -4,7 +4,7 @@ has_endstop: true
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:
     kp: [6, 6, 6]

--- a/config/finger_0.yml
+++ b/config/finger_0.yml
@@ -4,7 +4,7 @@ has_endstop: true
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:
     kp: [6, 6, 6]

--- a/config/finger_120.yml
+++ b/config/finger_120.yml
@@ -4,7 +4,7 @@ has_endstop: true
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:
     kp: [6, 6, 6]

--- a/config/finger_240.yml
+++ b/config/finger_240.yml
@@ -4,7 +4,7 @@ has_endstop: true
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:
     kp: [6, 6, 6]

--- a/config/finger_legacy.yml
+++ b/config/finger_legacy.yml
@@ -8,7 +8,7 @@ has_endstop: true
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:
     kp: [3, 3, 3]

--- a/config/fingeredu.yml
+++ b/config/fingeredu.yml
@@ -4,7 +4,7 @@ has_endstop: false
 calibration:
     endstop_search_torques_Nm: [0.22, 0.22, -0.18]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:
     kp: [7, 7, 6.5]

--- a/config/fingeredu_0.yml
+++ b/config/fingeredu_0.yml
@@ -7,7 +7,7 @@ calibration:
         - 0.22
         - -0.18
     position_tolerance_rad: 0.05
-    move_timeout: 500
+    move_steps: 500
 safety_kd:
     - 0.09
     - 0.09

--- a/config/fingeredu_120.yml
+++ b/config/fingeredu_120.yml
@@ -7,7 +7,7 @@ calibration:
         - 0.22
         - -0.18
     position_tolerance_rad: 0.05
-    move_timeout: 500
+    move_steps: 500
 safety_kd:
     - 0.09
     - 0.09

--- a/config/fingeredu_240.yml
+++ b/config/fingeredu_240.yml
@@ -7,7 +7,7 @@ calibration:
         - 0.22
         - -0.18
     position_tolerance_rad: 0.05
-    move_timeout: 500
+    move_steps: 500
 safety_kd:
     - 0.09
     - 0.09

--- a/config/onejoint.yml
+++ b/config/onejoint.yml
@@ -7,7 +7,7 @@ has_endstop: true
 calibration:
     endstop_search_torques_Nm: [-0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.08]
 position_control_gains:
     kp: [3]

--- a/config/onejoint_friction_calibration.yml
+++ b/config/onejoint_friction_calibration.yml
@@ -8,7 +8,7 @@ has_endstop: false
 calibration:
     endstop_search_torques_Nm: [-0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.02]
 position_control_gains:
     kp: [6]

--- a/config/onejoint_high_load.yaml
+++ b/config/onejoint_high_load.yaml
@@ -5,7 +5,7 @@ has_endstop: true
 calibration:
     endstop_search_torques_Nm: [-0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.05]
 position_control_gains:
     kp: [6]

--- a/config/single_finger_test.yml
+++ b/config/single_finger_test.yml
@@ -4,7 +4,7 @@ has_endstop: false
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:
     kp: [4, 4, 4]

--- a/config/trifinger.yml
+++ b/config/trifinger.yml
@@ -13,7 +13,7 @@ calibration:
         - -0.22
         - -0.22
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd:
     - 0.09
     - 0.09

--- a/config/trifingeredu.yml
+++ b/config/trifingeredu.yml
@@ -13,7 +13,7 @@ calibration:
         - 0.22
         - -0.18
     position_tolerance_rad: 0.05
-    move_timeout: 500
+    move_steps: 500
 safety_kd:
     - 0.09
     - 0.09

--- a/config/trifingerpro.yml
+++ b/config/trifingerpro.yml
@@ -13,7 +13,7 @@ calibration:
         - +0.22
         - -0.22
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd:
     - 0.09
     - 0.09

--- a/config/twojoint.yml
+++ b/config/twojoint.yml
@@ -7,7 +7,7 @@ has_endstop: true
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22]
     position_tolerance_rad: 0.05
-    move_timeout: 2000
+    move_steps: 500
 safety_kd: [0.08, 0.08]
 position_control_gains:
     kp: [3, 3]


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

According to the change in https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/75 replace the `move_timeout` with `move_steps` in all robot config files.


## How I Tested

Executed demos on MonoFingerOne and TriFingerOne.

## Do not merge before

- [x] https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/75

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
