### PR TITLE
Move robot to rest position during shutdown

### DIFF
--- a/include/robot_fingers/n_finger_driver.hpp
+++ b/include/robot_fingers/n_finger_driver.hpp
@@ -26,12 +26,14 @@ class NFingerDriver : public blmc_robots::NJointBlmcRobotDriver<
                           N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>
 {
 public:
-    typedef robot_interfaces::NFingerObservation<N_FINGERS> Observation;
-
-    using blmc_robots::NJointBlmcRobotDriver<
+    typedef blmc_robots::NJointBlmcRobotDriver<
         robot_interfaces::NFingerObservation<N_FINGERS>,
         N_FINGERS * robot_interfaces::JOINTS_PER_FINGER,
-        N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>::NJointBlmcRobotDriver;
+        N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>
+        NJointBlmcRobotDriver;
+    typedef robot_interfaces::NFingerObservation<N_FINGERS> Observation;
+
+    using NJointBlmcRobotDriver::NJointBlmcRobotDriver;
 
     Observation get_latest_observation() override
     {
@@ -66,6 +68,32 @@ public:
         }
 
         return observation;
+    }
+
+    void shutdown() override
+    {
+        std::cout << "Shutdown Finger.  Move to rest position." << std::endl;
+
+        // move back to initial position
+        // TODO use different number of move_steps here?
+        bool success = this->move_to_position(
+            this->config_.initial_position_rad,
+            this->config_.calibration.position_tolerance_rad,
+            this->config_.calibration.move_steps);
+
+        // TODO: after reaching the initial position move to an even more safe
+        // rest position directly at the end stops (this should guarantee
+        // success when homing next time).
+
+        NJointBlmcRobotDriver::shutdown();
+
+        if (!success)
+        {
+            // TODO: report this somehow as this probably means that someone
+            // needs to disentangle the robot manually.
+            throw std::runtime_error(
+                "Failed to reach rest position.  Fingers may be blocked.");
+        }
     }
 };
 


### PR DESCRIPTION
## Description

Use the `shutdown()` method of the driver to move the robot back to the initial position before stopping completely.

This ensures the robot is moved to a good position to start the next run while it is still initialized (i.e. it can be detected if it is blocked and does not reach the target position).  This is mostly relevant for TriFingerPro, which can get stuck during homing when starting from a bad position.

For now it only moves back to the initial position as this was fast to implement.  Ideally for TriFingerPro would be to add a separate "rest position" which is directly at the end-stops that are targeted during homing.  With this, it would be absolutely guaranteed that the fingers cannot get stuck during homing (with the current solution using the initial position this is unlikely but not impossible).

## How I Tested

On Mono- and TriFingerOne.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/75

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
