### PR TITLE
Script for fast home offset calibration of TriFingerPro

### DIFF
--- a/config/trifingerpro_for_calib.yml
+++ b/config/trifingerpro_for_calib.yml
@@ -1,0 +1,35 @@
+can_ports: ["can0", "can1", "can2", "can3", "can4", "can5"]
+max_current_A: 2.0
+has_endstop: true
+calibration:
+    endstop_search_torques_Nm: 
+        - +0.22
+        - +0.22
+        - -0.22
+        - +0.22
+        - +0.22
+        - -0.22
+        - +0.22
+        - +0.22
+        - -0.22
+    position_tolerance_rad: 0.05
+    move_timeout: 500
+safety_kd:
+    - 0.09
+    - 0.09
+    - 0.05
+    - 0.09
+    - 0.09
+    - 0.05
+    - 0.09
+    - 0.09
+    - 0.05
+position_control_gains:
+    kp: [4, 4, 4, 4, 4, 4, 4, 4, 4]
+    kd: [0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.01]
+
+
+hard_position_limits_lower: [-.inf, -.inf, -.inf, -.inf, -.inf, -.inf, -.inf, -.inf, -.inf]
+hard_position_limits_upper: [.inf, .inf, .inf, .inf, .inf, .inf, .inf, .inf, .inf]
+home_offset_rad: [0, 0, 0, 0, 0, 0, 0, 0, 0]
+initial_position_rad: [0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/python/robot_fingers/robot.py
+++ b/python/robot_fingers/robot.py
@@ -39,6 +39,11 @@ robot_configs = {
         robot_fingers.create_trifinger_backend,
         "trifingerpro.yml",
     ),
+    "trifingerpro_calib": (
+        robot_interfaces.trifinger,
+        robot_fingers.create_trifinger_backend,
+        "trifingerpro_for_calib.yml",
+    ),
     "onejoint": (
         robot_interfaces.one_joint,
         robot_fingers.create_one_joint_backend,

--- a/scripts/trifingerpro_offset_calibration.py
+++ b/scripts/trifingerpro_offset_calibration.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Home Offset Calibration for TriFingerPro.
+
+To calibrate the home offset values of a TriFingerPro robot, run this script
+and wait until the robot is initialized.  Then move all joints back to the
+end-stops to which they moved during initialization.  Make sure each joint is
+touching the end-stop bumper but not pushing against it with force.  Then press
+enter to determine the home offset.  The home offset values that are printed
+can directly be copied to the configuration file of the robot.
+
+"""
+import numpy as np
+
+import robot_fingers
+
+
+# Distance from the zero position (finger pointing straight down) to the
+# end-stop.  This is independent of the placement of the encoder disc and thus
+# should be the same on all TriFingerPro robots.
+zero_to_endstop = np.array([
+    2.112,  2.399, -2.714,  2.118,  2.471, -2.694,  2.179,  2.456, -2.723
+])
+
+
+def main():
+    robot = robot_fingers.Robot.create_by_name("trifingerpro_calib")
+    robot.initialize()
+
+    action = robot.Action()
+    t = robot.frontend.append_desired_action(action)
+    robot.frontend.wait_until_timeindex(t)
+
+    print()
+    input("Move fingers to end stops so that it touches without force."
+          " Then press enter.")
+
+    t = robot.frontend.append_desired_action(action)
+    obs = robot.frontend.get_observation(t)
+
+    n_joints = 9
+    format_string = ", ".join(["{: 6.3f}"] * n_joints)
+
+    home_to_endstop = obs.position
+    endstop_to_zero = -zero_to_endstop
+
+    home_to_zero = home_to_endstop + endstop_to_zero
+    print("End-stop position:", format_string.format(*obs.position))
+    print()
+    print("Home Offset:", format_string.format(*home_to_zero))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Script for calibrating home offset of TriFingerPro robots that uses the
end-stop as fixed position.  That is, for determining the offset, the
finger does not need to be manually moved to the zero position but to
the end-stop which is much easier and more repeatable.


## How I Tested

Used for the new platforms


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
