### PR TITLE
Look for TriFingerPro config in home directory rather than in the package

### DIFF
--- a/demos/demo_trifingerpro.py
+++ b/demos/demo_trifingerpro.py
@@ -63,9 +63,7 @@ def main():
     else:
         # In single-process case run both frontend and backend in this process
         # (using the `Robot` helper class).
-        robot = robot_fingers.Robot(robot_interfaces.trifinger,
-                                    robot_fingers.create_trifinger_backend,
-                                    "trifingerpro.yml")
+        robot = robot_fingers.Robot.create_by_name("trifingerpro")
         if args.log:
             logger = robot_interfaces.trifinger.Logger(robot.robot_data, 100)
             logger.start(args.log)

--- a/python/robot_fingers/robot.py
+++ b/python/robot_fingers/robot.py
@@ -37,6 +37,15 @@ robot_configs = {
     "trifingerpro": (
         robot_interfaces.trifinger,
         robot_fingers.create_trifinger_backend,
+        os.path.join(
+            os.path.expanduser(os.getenv("XDG_CONFIG_HOME", "~/.config")),
+            "trifingerpro",
+            "trifingerpro.yml",
+        )
+    ),
+    "trifingerpro_default": (
+        robot_interfaces.trifinger,
+        robot_fingers.create_trifinger_backend,
         "trifingerpro.yml",
     ),
     "trifingerpro_calib": (

--- a/python/robot_fingers/robot.py
+++ b/python/robot_fingers/robot.py
@@ -89,18 +89,24 @@ class Robot:
         :param robot_module: The module that defines the robot classes (i.e.
             `Data`, `Frontend`, `Backend`, ...)
         :param create_backend_function: Function to create the robot backend.
-        :param config_file_name: Name of the config file (expected to be
-            located in robot_fingers/config).
+        :param config_file_name: Either an absolute path to a config file
+            (needs to start with "/" in this case) or the name of a config
+            file located in robot_fingers/config.
         """
         # convenience mapping of the Action type
         self.Action = robot_module.Action
 
-        # Use the default config file from the robot_fingers package
-        config_file_path = os.path.join(
-            rospkg.RosPack().get_path("robot_fingers"),
-            "config",
-            config_file_name,
-        )
+        # If config_file_name starts with "/" assume it is an absolute path and
+        # use it as is.  Otherwise interpret it relative to the config
+        # directory of the robot_fingers package.
+        if config_file_name.startswith("/"):
+            config_file_path = config_file_name
+        else:
+            config_file_path = os.path.join(
+                rospkg.RosPack().get_path("robot_fingers"),
+                "config",
+                config_file_name,
+            )
 
         # Storage for all observations, actions, etc.
         self.robot_data = robot_module.SingleProcessData()


### PR DESCRIPTION
## Description

For the TriFingerPro platforms, we have different config files (due to different home offsets) for otherwise identical platforms.  To make it easier to maintain this, the scripts for TriFingerPro robots are now not using the config file from the package anymore but instead expect it to be located at `~/.config/trifingerpro/trifingerpro.yml`.  So when setting up a new PC, the config file from this repo should be used as a template and be copied there.  Then the home offsets can be changed there.

For this to be possible, the `Robot` class is extended a bit to also accept absolute paths to config files (they need to start with "/").

## How I Tested

On one TriFingerPro platform (running the demo).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
