### PR TITLE
Replace move_timeout with move_steps

### DIFF
--- a/config/trifingerpro_for_calib.yml
+++ b/config/trifingerpro_for_calib.yml
@@ -13,7 +13,7 @@ calibration:
         - +0.22
         - -0.22
     position_tolerance_rad: 0.05
-    move_timeout: 500
+    move_steps: 500
 safety_kd:
     - 0.09
     - 0.09


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The "move_timeout" setting was replaced with "move_steps" some time ago.
Seems like this config file was not updated together with the others.

## How I Tested

Running the calibration on TriFingerPro.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
