### PR TITLE
Use shutdown_trajectory for TriFingerPro, update config files

### DIFF
--- a/config/finger.yml
+++ b/config/finger.yml
@@ -1,9 +1,9 @@
 can_ports: ["can0", "can1"]
 max_current_A: 2
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:

--- a/config/finger_0.yml
+++ b/config/finger_0.yml
@@ -1,9 +1,9 @@
 can_ports: ["can0", "can1"]
 max_current_A: 2
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:

--- a/config/finger_120.yml
+++ b/config/finger_120.yml
@@ -1,9 +1,9 @@
 can_ports: ["can2", "can3"]
 max_current_A: 2
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:

--- a/config/finger_240.yml
+++ b/config/finger_240.yml
@@ -1,9 +1,9 @@
 can_ports: ["can4", "can5"]
 max_current_A: 2
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:

--- a/config/finger_legacy.yml
+++ b/config/finger_legacy.yml
@@ -5,9 +5,9 @@
 can_ports: ["can0", "can1"]
 max_current_A: 2
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:

--- a/config/fingeredu.yml
+++ b/config/fingeredu.yml
@@ -1,9 +1,9 @@
 can_ports: ["can2", "can3"]
 max_current_A: 2
 has_endstop: false
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [0.22, 0.22, -0.18]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:

--- a/config/fingeredu_0.yml
+++ b/config/fingeredu_0.yml
@@ -1,12 +1,12 @@
 can_ports: ["can0", "can1"]
 max_current_A: 2.0
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: 
         - 0.22
         - 0.22
         - -0.18
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd:
     - 0.09

--- a/config/fingeredu_120.yml
+++ b/config/fingeredu_120.yml
@@ -1,12 +1,12 @@
 can_ports: ["can2", "can3"]
 max_current_A: 2.0
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: 
         - 0.22
         - 0.22
         - -0.18
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd:
     - 0.09

--- a/config/fingeredu_240.yml
+++ b/config/fingeredu_240.yml
@@ -1,12 +1,12 @@
 can_ports: ["can4", "can5"]
 max_current_A: 2.0
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: 
         - 0.22
         - 0.22
         - -0.18
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd:
     - 0.09

--- a/config/onejoint.yml
+++ b/config/onejoint.yml
@@ -4,9 +4,9 @@ can_ports: ["can6"]
 
 max_current_A: 2
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.08]
 position_control_gains:

--- a/config/onejoint_friction_calibration.yml
+++ b/config/onejoint_friction_calibration.yml
@@ -5,9 +5,9 @@ can_ports: ["can7"]
 
 max_current_A: 2
 has_endstop: false
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.02]
 position_control_gains:

--- a/config/onejoint_high_load.yaml
+++ b/config/onejoint_high_load.yaml
@@ -2,9 +2,9 @@ can_ports: ["can1"]
 
 max_current_A: 17
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.05]
 position_control_gains:

--- a/config/single_finger_test.yml
+++ b/config/single_finger_test.yml
@@ -1,9 +1,9 @@
 can_ports: ["can0", "can1"]
 max_current_A: 2
 has_endstop: false
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.08, 0.08, 0.04]
 position_control_gains:

--- a/config/trifinger.yml
+++ b/config/trifinger.yml
@@ -1,6 +1,7 @@
 can_ports: ["can0", "can1", "can2", "can3", "can4", "can5"]
 max_current_A: 2.0
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: 
         - -0.22
@@ -12,7 +13,6 @@ calibration:
         - -0.22
         - -0.22
         - -0.22
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd:
     - 0.09

--- a/config/trifingeredu.yml
+++ b/config/trifingeredu.yml
@@ -1,6 +1,7 @@
 can_ports: ["can0", "can1", "can2", "can3", "can4", "can5"]
 max_current_A: 2.0
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: 
         - 0.22
@@ -12,7 +13,6 @@ calibration:
         - 0.22
         - 0.22
         - -0.18
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd:
     - 0.09

--- a/config/trifingerpro.yml
+++ b/config/trifingerpro.yml
@@ -1,8 +1,9 @@
 can_ports: ["can0", "can1", "can2", "can3", "can4", "can5"]
 max_current_A: 2.0
 has_endstop: true
+move_to_position_tolerance_rad: 0.07
 calibration:
-    endstop_search_torques_Nm: 
+    endstop_search_torques_Nm:
         - +0.22
         - +0.22
         - -0.22
@@ -12,7 +13,6 @@ calibration:
         - +0.22
         - +0.22
         - -0.22
-    position_tolerance_rad: 0.07
     move_steps: 500
 safety_kd:
     - 0.09
@@ -99,3 +99,11 @@ initial_position_rad:
     - 0.9
     - -1.7
 
+shutdown_trajectory:
+    # first move slowly back to initial position
+    - target_position_rad: [0, 0.9, -1.7, 0, 0.9, -1.7, 0, 0.9, -1.7]
+      move_steps: 3000
+    # then move to rest position (a position from which it cannot get stuck
+    # during homing for the next run).
+    - target_position_rad: [0.0161, 0.8998, -0.9770, 0.0161, 0.8998, -0.9770, 0.0161, 0.8998, -0.9770]
+      move_steps: 1000

--- a/config/trifingerpro_for_calib.yml
+++ b/config/trifingerpro_for_calib.yml
@@ -1,6 +1,7 @@
 can_ports: ["can0", "can1", "can2", "can3", "can4", "can5"]
 max_current_A: 2.0
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: 
         - +0.22
@@ -12,7 +13,6 @@ calibration:
         - +0.22
         - +0.22
         - -0.22
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd:
     - 0.09

--- a/config/twojoint.yml
+++ b/config/twojoint.yml
@@ -4,9 +4,9 @@ can_ports: ["can6"]
 
 max_current_A: 2
 has_endstop: true
+move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22]
-    position_tolerance_rad: 0.05
     move_steps: 500
 safety_kd: [0.08, 0.08]
 position_control_gains:

--- a/include/robot_fingers/n_finger_driver.hpp
+++ b/include/robot_fingers/n_finger_driver.hpp
@@ -32,6 +32,7 @@ public:
         N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>
         NJointBlmcRobotDriver;
     typedef robot_interfaces::NFingerObservation<N_FINGERS> Observation;
+    using typename NJointBlmcRobotDriver::Vector;
 
     using NJointBlmcRobotDriver::NJointBlmcRobotDriver;
 
@@ -68,32 +69,6 @@ public:
         }
 
         return observation;
-    }
-
-    void shutdown() override
-    {
-        std::cout << "Shutdown Finger.  Move to rest position." << std::endl;
-
-        // move back to initial position
-        // TODO use different number of move_steps here?
-        bool success = this->move_to_position(
-            this->config_.initial_position_rad,
-            this->config_.calibration.position_tolerance_rad,
-            this->config_.calibration.move_steps);
-
-        // TODO: after reaching the initial position move to an even more safe
-        // rest position directly at the end stops (this should guarantee
-        // success when homing next time).
-
-        NJointBlmcRobotDriver::shutdown();
-
-        if (!success)
-        {
-            // TODO: report this somehow as this probably means that someone
-            // needs to disentangle the robot manually.
-            throw std::runtime_error(
-                "Failed to reach rest position.  Fingers may be blocked.");
-        }
     }
 };
 


### PR DESCRIPTION
## Description
Use the "shutdown_trajectory" added in https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/78 instead of implementing a custom `shutdown()` method for `NFingerDriver`.

Update all config files to the renaming of `calibration/position_tolerance_rad` to `move_to_position_tolerance_rad`.


## How I Tested

On TriFingerPro.


## Do not merge before

- [x] https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/78

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
