### PR TITLE
Change soft limits to prevent collisions with motors

### DIFF
--- a/config/trifingerpro.yml
+++ b/config/trifingerpro.yml
@@ -53,24 +53,25 @@ hard_position_limits_upper:
     - 1.67
     - 2.8
 
+# Set limits such that the motors cannot collide with the middle links
 soft_position_limits_lower:
     - -0.9
-    - -1.57
+    - 0.0
     - -2.7
     - -0.9
-    - -1.57
+    - 0.0
     - -2.7
     - -0.9
-    - -1.57
+    - 0.0
     - -2.7
 soft_position_limits_upper:
-    - 1.4
+    - 1.0
     - 1.57
     - 0.0
-    - 1.4
+    - 1.0
     - 1.57
     - 0.0
-    - 1.4
+    - 1.0
     - 1.57
     - 0.0
 


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Change the soft position limits in trifingerpro.yml such that collisions
of the motors with the middle links of the other fingers should not
happen anymore.

Biggest restriction is that the middle link cannot go forward anymore beyond the zero position.

## How I Tested

On TriFingerPro



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
