### PR TITLE
Store config in /etc/trifingerpro

### DIFF
--- a/python/robot_fingers/robot.py
+++ b/python/robot_fingers/robot.py
@@ -37,11 +37,7 @@ robot_configs = {
     "trifingerpro": (
         robot_interfaces.trifinger,
         robot_fingers.create_trifinger_backend,
-        os.path.join(
-            os.path.expanduser(os.getenv("XDG_CONFIG_HOME", "~/.config")),
-            "trifingerpro",
-            "trifingerpro.yml",
-        )
+        "/etc/trifingerpro/trifingerpro.yml",
     ),
     "trifingerpro_default": (
         robot_interfaces.trifinger,


### PR DESCRIPTION

## Description

There was some misunderstanding on the structure of the submission
system.  Submissions run under the account of the corresponding user, so
the config needs to be stored in some global location outside of the
home directory.


## How I Tested
On a TriFingerPro platform.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
