### PR TITLE
Backend: Start camera log only when first action is sent

### DIFF
--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -85,6 +85,13 @@ def main():
     # Initializes the robot (e.g. performs homing).
     backend.initialize()
 
+    if args.fake_object_tracker:
+        import trifinger_object_tracking.py_object_tracker as object_tracker
+        object_tracker_data = object_tracker.Data("object_tracker", True)
+        object_tracker_backend = object_tracker.FakeBackend(  # noqa
+            object_tracker_data
+        )
+
     if args.cameras and args.camera_logfile:
         camera_fps = 100
         robot_rate_hz = 1000
@@ -93,16 +100,13 @@ def main():
         # 10% buffer
         log_size = int(camera_fps * episode_length_s * 1.1)
 
-        print("Start camera logger with buffer size", log_size)
+        print("Initialize camera logger with buffer size", log_size)
         camera_logger = trifinger_cameras.tricamera.Logger(camera_data, log_size)
+        backend.wait_until_first_action()
         camera_logger.start()
+        print("Start camera logging", log_size)
 
-    if args.fake_object_tracker:
-        import trifinger_object_tracking.py_object_tracker as object_tracker
-        object_tracker_data = object_tracker.Data("object_tracker", True)
-        object_tracker_backend = object_tracker.FakeBackend(  # noqa
-            object_tracker_data
-        )
+
 
     backend.wait_until_terminated()
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Wait until the user sends the first action before starting the camera log.  This way, we do not log unnecessary data before the start.


## How I Tested

On TriFingerPro.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/78

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
