### PR TITLE
backend: Add "ready indicator" option

### DIFF
--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -19,10 +19,7 @@ def main():
         """,
     )
     parser.add_argument(
-        "--cameras",
-        "-c",
-        action="store_true",
-        help="Run camera backend.",
+        "--cameras", "-c", action="store_true", help="Run camera backend.",
     )
     parser.add_argument(
         "--fake-object-tracker",
@@ -96,6 +93,7 @@ def main():
 
     if args.fake_object_tracker:
         import trifinger_object_tracking.py_object_tracker as object_tracker
+
         object_tracker_data = object_tracker.Data("object_tracker", True)
         object_tracker_backend = object_tracker.FakeBackend(  # noqa
             object_tracker_data
@@ -110,7 +108,9 @@ def main():
         log_size = int(camera_fps * episode_length_s * 1.1)
 
         print("Initialize camera logger with buffer size", log_size)
-        camera_logger = trifinger_cameras.tricamera.Logger(camera_data, log_size)
+        camera_logger = trifinger_cameras.tricamera.Logger(
+            camera_data, log_size
+        )
 
     # if specified, create the "ready indicator" file to indicate that the
     # backend is ready
@@ -130,7 +130,9 @@ def main():
         pathlib.Path(args.ready_indicator).unlink()
 
     if args.cameras and args.camera_logfile:
-        print("Save recorded camera data to file {}".format(args.camera_logfile))
+        print(
+            "Save recorded camera data to file {}".format(args.camera_logfile)
+        )
         camera_logger.stop_and_save(args.camera_logfile)
 
     if args.robot_logfile:

--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 """Run TriFinger back-end using multi-process robot data."""
 import argparse
-import os
-
-import rospkg
+import pathlib
 
 import robot_interfaces
 import robot_fingers
@@ -43,6 +41,14 @@ def main():
         type=str,
         help="""Path to a file to which the camera data is written.  If not
             specified, no log is generated.
+        """,
+    )
+    parser.add_argument(
+        "--ready-indicator",
+        type=str,
+        metavar="READY_INDICATOR_FILE",
+        help="""Path to a file that will be created once the backend is ready
+            and will be deleted again when it stops (before storing the logs).
         """,
     )
     args = parser.parse_args()
@@ -105,13 +111,23 @@ def main():
 
         print("Initialize camera logger with buffer size", log_size)
         camera_logger = trifinger_cameras.tricamera.Logger(camera_data, log_size)
+
+    # if specified, create the "ready indicator" file to indicate that the
+    # backend is ready
+    if args.ready_indicator:
+        pathlib.Path(args.ready_indicator).touch()
+
+    if args.cameras and args.camera_logfile:
         backend.wait_until_first_action()
         camera_logger.start()
-        print("Start camera logging", log_size)
-
-
+        print("Start camera logging")
 
     backend.wait_until_terminated()
+
+    # delete the ready indicator file to indicate that the backend has shut
+    # down
+    if args.ready_indicator:
+        pathlib.Path(args.ready_indicator).unlink()
 
     if args.cameras and args.camera_logfile:
         print("Save recorded camera data to file {}".format(args.camera_logfile))


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add option `--ready-indicator` to `trifinger_backend.py`.  If set, the specified file will be created once the backend is ready with initialization and will be deleted when it is shut down.  This can be used by the submission system runscript to see the current state.

Also run black to reformat the file.

## How I Tested

In the submission system.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
