### PR TITLE
More restrictive joint limits for TriFingerPro

### DIFF
--- a/config/trifingerpro.yml
+++ b/config/trifingerpro.yml
@@ -55,13 +55,13 @@ hard_position_limits_upper:
 
 # Set limits such that the motors cannot collide with the middle links
 soft_position_limits_lower:
-    - -0.9
+    - -0.33
     - 0.0
     - -2.7
-    - -0.9
+    - -0.33
     - 0.0
     - -2.7
-    - -0.9
+    - -0.33
     - 0.0
     - -2.7
 soft_position_limits_upper:


### PR DESCRIPTION
## Description

With these joint limits, it should be impossible for the middle link of
one finger to collide with a motor of another finger.


## How I Tested

On TriFingerPro 2



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
