### PR TITLE
Use binary log format for TriFinger and add script for converting log

### DIFF
--- a/scripts/robot_log_dat2csv.py
+++ b/scripts/robot_log_dat2csv.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Convert a binary log file into a plain text csv file."""
+import argparse
+import numpy as np
+
+import robot_interfaces
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("infile", type=str, help="Binary input file.")
+    parser.add_argument("outfile", type=str, help="Output CSV file.")
+    parser.add_argument(
+        "--number-of-fingers",
+        "-n",
+        type=int,
+        choices=[1, 3],
+        default=3,
+        help="Number of fingers of the robot.",
+    )
+    args = parser.parse_args()
+
+    if args.number_of_fingers == 1:
+        module = robot_interfaces.finger
+    else:
+        module = robot_interfaces.trifinger
+
+    log = module.BinaryLogReader(args.infile)
+
+    n_fingers = args.number_of_fingers
+    n_joints = n_fingers * 3
+
+    header = ["#time_index", "timestamp"]
+    header += ["status_action_repetitions", "status_error_status"]
+
+    header += ["observation_position_%d" % i for i in range(n_joints)]
+    header += ["observation_velocity_%d" % i for i in range(n_joints)]
+    header += ["observation_torque_%d" % i for i in range(n_joints)]
+    header += ["observation_tip_force_%d" % i for i in range(n_fingers)]
+
+    for action_type in ("applied_action", "desired_action"):
+        for field in ("torque", "position", "position_kp", "position_kd"):
+            header += [
+                "%s_%s_%d" % (action_type, field, i) for i in range(n_joints)
+            ]
+
+    all_data = []
+    for entry in log.data:
+        data = [
+            entry.timeindex,
+            entry.timestamp,
+            entry.status.action_repetitions,
+            int(entry.status.error_status),
+        ]
+
+        data += [entry.observation.position[i] for i in range(n_joints)]
+        data += [entry.observation.velocity[i] for i in range(n_joints)]
+        data += [entry.observation.torque[i] for i in range(n_joints)]
+        data += [entry.observation.tip_force[i] for i in range(n_fingers)]
+
+        data += [entry.applied_action.torque[i] for i in range(n_joints)]
+        data += [entry.applied_action.position[i] for i in range(n_joints)]
+        data += [entry.applied_action.position_kp[i] for i in range(n_joints)]
+        data += [entry.applied_action.position_kd[i] for i in range(n_joints)]
+
+        data += [entry.desired_action.torque[i] for i in range(n_joints)]
+        data += [entry.desired_action.position[i] for i in range(n_joints)]
+        data += [entry.desired_action.position_kp[i] for i in range(n_joints)]
+        data += [entry.desired_action.position_kd[i] for i in range(n_joints)]
+
+        all_data.append(data)
+
+    np.savetxt(args.outfile, all_data, header=" ".join(header))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -154,7 +154,8 @@ def main():
             end_index = args.max_number_of_actions
         else:
             end_index = -1
-        robot_logger.write_current_buffer(
+
+        robot_logger.write_current_buffer_binary(
             args.robot_logfile, start_index=0, end_index=end_index
         )
 


### PR DESCRIPTION
## Description

- Use the binary log format in trifinger_backend.py
- Add a script to convert binary log file to csv file.


## How I Tested

See https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/81.

## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/81

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
