### PR TITLE
Add TriFingerPlatformLog for loading combined logs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,9 @@ catkin_python_setup()
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include ${EIGEN3_INCLUDE_DIR}
-  LIBRARIES trifinger_platform_frontend
+  LIBRARIES
+    trifinger_platform_frontend
+    trifinger_platform_log
   CATKIN_DEPENDS
     blmc_robots
     robot_interfaces
@@ -63,11 +65,22 @@ target_link_libraries(trifinger_platform_frontend
     ${OpenCV_LIBRARIES}
 )
 
+add_library(trifinger_platform_log
+    src/trifinger_platform_log.cpp
+)
+target_link_libraries(trifinger_platform_log
+    ${catkin_LIBRARIES}
+    trifinger_platform_frontend
+)
+
+
+
 # Python Bindings
 catkin_add_pybind11_module(py_one_joint)
 catkin_add_pybind11_module(py_two_joint)
 catkin_add_pybind11_module(py_real_finger)
-catkin_add_pybind11_module(py_trifinger trifinger_platform_frontend)
+catkin_add_pybind11_module(py_trifinger
+    trifinger_platform_frontend trifinger_platform_log)
 
 
 # Demo executable

--- a/demos/demo_trifinger_platform_log.py
+++ b/demos/demo_trifinger_platform_log.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Demo showing how to use TriFingerPlatformLog."""
+import argparse
+
+import cv2
+
+import robot_fingers
+import trifinger_cameras  # noqa  -- needed for camera observation
+from trifinger_cameras import utils
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("robot_log", type=str, help="Robot log file")
+    parser.add_argument("camera_log", type=str, help="Camera log file")
+    args = parser.parse_args()
+
+    log = robot_fingers.TriFingerPlatformLog(args.robot_log, args.camera_log)
+
+    # iterate over all robot time steps in the log
+    for t in range(log.get_first_timeindex(), log.get_last_timeindex() + 1):
+        # TriFingerPlatformLog provides the same getters as
+        # TriFingerPlatformFrontend:
+
+        robot_observation = log.get_robot_observation(t)
+        # print position of the first finger
+        print(robot_observation.position[:3])
+
+        # show images of camera180
+        try:
+            camera_observation = log.get_camera_observation(t)
+            cv2.imshow(
+                "camera180",
+                utils.convert_image(camera_observation.cameras[1].image),
+            )
+            cv2.waitKey(1)
+        except Exception as e:
+            print(e)
+
+
+if __name__ == "__main__":
+    main()

--- a/include/robot_fingers/trifinger_platform_log.hpp
+++ b/include/robot_fingers/trifinger_platform_log.hpp
@@ -1,0 +1,88 @@
+/**
+ * @file
+ * @brief Access combined log of a TriFinger platform.
+ * @copyright 2020, Max Planck Gesellschaft.  All rights reserved.
+ * @license BSD 3-clause
+ */
+#pragma once
+
+#include <robot_interfaces/finger_types.hpp>
+#include <robot_interfaces/sensors/sensor_log_reader.hpp>
+#include <trifinger_cameras/tricamera_observation.hpp>
+
+namespace robot_fingers
+{
+/**
+ * @brief Load robot and camera log and match observations like during runtime.
+ *
+ * The robot and camera observations are provided asynchronously.  To access
+ * both through a common time index, the @ref TriFingerPlatformFrontend class
+ * maps "robot time indices" to the corresponding camera observations based on
+ * the time stamps.  This mapping is not explicitly saved in the log files.
+ * Therefore, the TriFingerPlatformLog class provides an interface to load
+ * robot and camera logs together and performs the mapping from robot to camera
+ * time index in the same way as it is happening in @ref
+ * TriFingerPlatformFrontend.
+ */
+class TriFingerPlatformLog
+{
+public:
+    // typedefs for easy access
+    typedef robot_interfaces::TriFingerTypes::Action Action;
+    typedef robot_interfaces::TriFingerTypes::Observation RobotObservation;
+    typedef robot_interfaces::Status RobotStatus;
+    typedef trifinger_cameras::TriCameraObservation CameraObservation;
+
+    TriFingerPlatformLog(const std::string &robot_log_file,
+                         const std::string &camera_log_file);
+
+    /**
+     * @brief Get robot observation of the time step t.
+     */
+    RobotObservation get_robot_observation(const time_series::Index &t) const;
+
+    /**
+     * @brief Get desired action of time step t.
+     */
+    Action get_desired_action(const time_series::Index &t) const;
+
+    /**
+     * @brief Get actually applied action of time step t.
+     */
+    Action get_applied_action(const time_series::Index &t) const;
+
+    /**
+     * @brief Get robot status of time step t.
+     */
+    RobotStatus get_robot_status(const time_series::Index &t) const;
+
+    /**
+     * @brief Get timestamp (in milliseconds) of time step t.
+     */
+    time_series::Timestamp get_timestamp_ms(const time_series::Index &t) const;
+
+    /**
+     * @brief Get camera images of time step t.
+     *
+     * @param t  Time index of the robot time series.  This is internally
+     *      mapped to the corresponding time index of the camera time series.
+     *
+     * @return Camera images of time step t.
+     */
+    CameraObservation get_camera_observation(const time_series::Index t) const;
+
+    //! @brief Get the time index of the first time step in the log.
+    time_series::Index get_first_timeindex() const;
+
+    //! @brief Get the time index of the last time step in the log.
+    time_series::Index get_last_timeindex() const;
+
+private:
+    robot_interfaces::TriFingerTypes::BinaryLogReader robot_log_;
+    robot_interfaces::SensorLogReader<CameraObservation> camera_log_;
+
+    time_series::Index robot_log_start_index_;
+
+    std::vector<int> map_robot_to_camera_index_;
+};
+}  // namespace robot_fingers

--- a/src/trifinger_platform_log.cpp
+++ b/src/trifinger_platform_log.cpp
@@ -1,0 +1,101 @@
+/**
+ * @file
+ * @brief Access combined log of a TriFinger platform.
+ * @copyright 2020, Max Planck Gesellschaft.  All rights reserved.
+ * @license BSD 3-clause
+ */
+#include <robot_fingers/trifinger_platform_log.hpp>
+
+namespace robot_fingers
+{
+TriFingerPlatformLog::TriFingerPlatformLog(const std::string &robot_log_file,
+                                           const std::string &camera_log_file)
+    : robot_log_(robot_log_file),
+      camera_log_(camera_log_file),
+      map_robot_to_camera_index_(robot_log_.data.size(), -1)
+{
+    if (robot_log_.data.empty())
+    {
+        throw std::runtime_error("Robot log is empty");
+    }
+    robot_log_start_index_ = robot_log_.data.front().timeindex;
+
+    // verify that the robot log is complete, i.e. there are no time steps
+    // missing
+    for (size_t i = 0; i < robot_log_.data.size(); i++)
+    {
+        if (i + robot_log_start_index_ != robot_log_.data[i].timeindex)
+        {
+            throw std::runtime_error("Robot log is incomplete.");
+        }
+    }
+
+    // for each robot log entry, find the matching camera log entry
+    int i_camera = 0;
+    for (size_t i_robot = 0; i_robot < robot_log_.data.size(); i_robot++)
+    {
+        // timestamp in robot log is in seconds, convert to milliseconds
+        auto stamp_robot_ms = robot_log_.data[i_robot].timestamp * 1000;
+
+        while (i_camera < camera_log_.timestamps.size() &&
+               stamp_robot_ms >= camera_log_.timestamps[i_camera])
+        {
+            i_camera++;
+        }
+        map_robot_to_camera_index_[i_robot] = i_camera - 1;
+    }
+}
+
+TriFingerPlatformLog::RobotObservation
+TriFingerPlatformLog::get_robot_observation(const time_series::Index &t) const
+{
+    return robot_log_.data.at(t - robot_log_start_index_).observation;
+}
+
+TriFingerPlatformLog::Action TriFingerPlatformLog::get_desired_action(
+    const time_series::Index &t) const
+{
+    return robot_log_.data.at(t - robot_log_start_index_).desired_action;
+}
+
+TriFingerPlatformLog::Action TriFingerPlatformLog::get_applied_action(
+    const time_series::Index &t) const
+{
+    return robot_log_.data.at(t - robot_log_start_index_).applied_action;
+}
+
+TriFingerPlatformLog::RobotStatus TriFingerPlatformLog::get_robot_status(
+    const time_series::Index &t) const
+{
+    return robot_log_.data.at(t - robot_log_start_index_).status;
+}
+
+time_series::Timestamp TriFingerPlatformLog::get_timestamp_ms(
+    const time_series::Index &t) const
+{
+    return robot_log_.data.at(t - robot_log_start_index_).timestamp;
+}
+
+TriFingerPlatformLog::CameraObservation
+TriFingerPlatformLog::get_camera_observation(const time_series::Index t) const
+{
+    int i_camera = map_robot_to_camera_index_.at(t - robot_log_start_index_);
+    if (i_camera < 0)
+    {
+        throw std::out_of_range("No camera observation for given time index.");
+    }
+
+    return camera_log_.data.at(i_camera);
+}
+
+time_series::Index TriFingerPlatformLog::get_first_timeindex() const
+{
+    return robot_log_start_index_;
+}
+
+time_series::Index TriFingerPlatformLog::get_last_timeindex() const
+{
+    return robot_log_.data.back().timeindex;
+}
+
+}  // namespace robot_fingers

--- a/srcpy/py_trifinger.cpp
+++ b/srcpy/py_trifinger.cpp
@@ -22,6 +22,7 @@
 
 #include <robot_fingers/trifinger_driver.hpp>
 #include <robot_fingers/trifinger_platform_frontend.hpp>
+#include <robot_fingers/trifinger_platform_log.hpp>
 
 using namespace pybind11::literals;
 using namespace robot_fingers;
@@ -66,5 +67,36 @@ PYBIND11_MODULE(py_trifinger, m)
              pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("get_current_timeindex",
              &TriFingerPlatformFrontend::get_current_timeindex,
+             pybind11::call_guard<pybind11::gil_scoped_release>());
+
+    pybind11::class_<TriFingerPlatformLog,
+                     std::shared_ptr<TriFingerPlatformLog>>(
+        m, "TriFingerPlatformLog")
+        .def(pybind11::init<const std::string&, const std::string&>(),
+             pybind11::arg("robot_log_file"),
+             pybind11::arg("camera_log_file"))
+        .def("get_robot_observation",
+             &TriFingerPlatformLog::get_robot_observation,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_camera_observation",
+             &TriFingerPlatformLog::get_camera_observation,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_desired_action",
+             &TriFingerPlatformLog::get_desired_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_applied_action",
+             &TriFingerPlatformLog::get_applied_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_robot_status",
+             &TriFingerPlatformLog::get_robot_status,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_timestamp_ms",
+             &TriFingerPlatformLog::get_timestamp_ms,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_first_timeindex",
+             &TriFingerPlatformLog::get_first_timeindex,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_last_timeindex",
+             &TriFingerPlatformLog::get_last_timeindex,
              pybind11::call_guard<pybind11::gil_scoped_release>());
 }


### PR DESCRIPTION
## Description

Class for loading robot and camera log together and doing the same "robot time index to camera observation" mapping as the
`TriFingerPlatformFrontend`.

It provides the same getter methods as `TriFingerPlatformFrontend` plus two methods for getting the first and last time index of the log.


## How I Tested

~Not yet tested.~
Update: Tested using log files from the submission system.


## Do not merge before

- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/80
- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/81

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
