### PR TITLE
Move code for printing time once an hour to utils class

### DIFF
--- a/demos/demo_trifinger.py
+++ b/demos/demo_trifinger.py
@@ -5,7 +5,6 @@ Moves the TriFinger robot with a hard-coded choreography for show-casing and
 testing.
 """
 import argparse
-import time
 import numpy as np
 
 import robot_interfaces
@@ -41,7 +40,7 @@ def run_choreography(frontend):
     pose_side_2 = pose_idle
     pose_side_3 = [deg45, -deg22, -deg45]
 
-    last_time_print = 0
+    time_printer = robot_fingers.utils.TimePrinter()
 
     while True:
         # initial pose
@@ -64,10 +63,7 @@ def run_choreography(frontend):
 
         # print current date/time every hour, so we can roughly see how long it
         # ran in case it crashes during a long-run-test.
-        now = time.time()
-        if now - last_time_print > 3600:
-            print(time.strftime("%F %T"))
-            last_time_print = now
+        time_printer.update()
 
 
 def main():

--- a/demos/demo_trifingeredu.py
+++ b/demos/demo_trifingeredu.py
@@ -5,7 +5,6 @@ Moves the TriFingerEdu robot with a hard-coded choreography for show-casing and
 testing.
 """
 import argparse
-import time
 import numpy as np
 
 import robot_interfaces
@@ -34,7 +33,7 @@ def run_choreography(frontend):
     pose_intermediate = [0.75, 1.2, -2.3]
     pose_up = [1.5, 1.5, -3.0]
 
-    last_time_print = 0
+    time_printer = robot_fingers.utils.TimePrinter()
 
     while True:
         # initial pose
@@ -44,10 +43,7 @@ def run_choreography(frontend):
 
         # print current date/time every hour, so we can roughly see how long it
         # ran in case it crashes during a long-run-test.
-        now = time.time()
-        if (now - last_time_print > 3600):
-            print(time.strftime("%F %T"))
-            last_time_print = now
+        time_printer.update()
 
 
 def main():

--- a/demos/demo_trifingerpro.py
+++ b/demos/demo_trifingerpro.py
@@ -5,8 +5,6 @@ Moves the TriFingerPro robot with a hard-coded choreography for show-casing and
 testing.
 """
 import argparse
-import time
-import numpy as np
 
 import robot_interfaces
 import robot_fingers
@@ -27,7 +25,7 @@ def run_choreography(frontend):
     pose_up = [1.3, 1.5, -2.6]
     pose_other_side_up = [-0.8, 1.5, -1.7]
 
-    last_time_print = 0
+    time_printer = robot_fingers.utils.TimePrinter()
 
     while True:
         # initial pose
@@ -39,10 +37,7 @@ def run_choreography(frontend):
 
         # print current date/time every hour, so we can roughly see how long it
         # ran in case it crashes during a long-run-test.
-        now = time.time()
-        if (now - last_time_print > 3600):
-            print(time.strftime("%F %T"))
-            last_time_print = now
+        time_printer.update()
 
 
 def main():
@@ -77,4 +72,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/python/robot_fingers/__init__.py
+++ b/python/robot_fingers/__init__.py
@@ -1,6 +1,8 @@
-from robot_fingers.py_real_finger import *
-from robot_fingers.py_trifinger import *
-from robot_fingers.py_one_joint import *
-from robot_fingers.py_two_joint import *
+from . import utils
 
-from robot_fingers.robot import Robot, demo_print_position
+from .py_real_finger import *
+from .py_trifinger import *
+from .py_one_joint import *
+from .py_two_joint import *
+
+from .robot import Robot, demo_print_position

--- a/python/robot_fingers/utils.py
+++ b/python/robot_fingers/utils.py
@@ -1,0 +1,32 @@
+import time
+
+
+class TimePrinter:
+    """Regularly print the current date/time and the passed duration in hours."""
+
+    def __init__(self, interval_s: float = 3600.0):
+        """Initialise.
+
+        Args:
+            interval_s:  Print interval in seconds.
+        """
+        #: Print interval in seconds
+        self.interval_s = interval_s
+        #: Timestamp when the printer started
+        self.start_time = time.time()
+        self.start_time_str = time.strftime("%F %H:%M")
+
+        self._last_time_print = 0.0
+
+    def update(self):
+        """Print time if the interval_s has passed since the last call."""
+        now = time.time()
+        if now - self._last_time_print > self.interval_s:
+            time_str = time.strftime("%F %H:%M")
+            duration_h = round((now - self.start_time) / 3600)
+            print(
+                "{} ({} h since {})".format(
+                    time_str, duration_h, self.start_time_str
+                )
+            )
+            self._last_time_print = now

--- a/scripts/fingeredu_endurance_test.py
+++ b/scripts/fingeredu_endurance_test.py
@@ -4,7 +4,6 @@
 Moves the finger around to random positions.  The joint ranges are limited to
 ensure that the finger does not hit, e.g. the electronics above it.
 """
-import time
 import os
 import numpy as np
 import rospkg
@@ -25,7 +24,7 @@ def get_random_position():
 
 def demo_position_commands(finger):
     """Demo for directly sending position commands."""
-    last_time_print = 0
+    time_printer = robot_fingers.utils.TimePrinter()
 
     while True:
         # Run a position controller that randomly changes the desired position
@@ -43,10 +42,7 @@ def demo_position_commands(finger):
 
         # print current date/time every hour, so we can roughly see how long it
         # ran in case it crashes during a long-run-test.
-        now = time.time()
-        if now - last_time_print > 3600:
-            print(time.strftime("%F %T"))
-            last_time_print = now
+        time_printer.update()
 
 
 def main():

--- a/scripts/trifingerpro_random.py
+++ b/scripts/trifingerpro_random.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 """Move TriFingerPro to random positions (with collisions)."""
 import numpy as np
-import time
 
 import robot_fingers
 
 
 def get_random_position():
     """Generate a random position within a save range."""
-    #position_min = np.array([-0.9, -1.57, -2.7] * 3)
-    #position_max = np.array([1.4, 1.57, 0] * 3)
+    # position_min = np.array([-0.9, -1.57, -2.7] * 3)
+    # position_max = np.array([1.4, 1.57, 0] * 3)
     position_min = np.array([-0.33, 0, -2.7] * 3)
     position_max = np.array([1.0, 1.57, 0] * 3)
 
@@ -21,20 +20,17 @@ def main():
     robot = robot_fingers.Robot.create_by_name("trifingerpro")
     robot.initialize()
 
-    last_time_print = 0
+    time_printer = robot_fingers.utils.TimePrinter()
 
     while True:
         action = robot.Action(position=get_random_position())
         for _ in range(1000):
             t = robot.frontend.append_desired_action(action)
-            pos = robot.frontend.get_observation(t).position
+            robot.frontend.wait_until_timeindex(t)
 
         # print current date/time every hour, so we can roughly see how long it
         # ran in case it crashes during a long-run-test.
-        now = time.time()
-        if (now - last_time_print > 3600):
-            print(time.strftime("%F %T"))
-            last_time_print = now
+        time_printer.update()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

To avoid redundancy, move the code snipped for printing the current
date/time once every hour, that is found in multiple scripts, to one
central utils class `TimePrinter`.

Also extend a bit to always add the number of hours since the start.

## How I Tested

Running it on TriFingerPro


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
