### PR TITLE
End-stop position test

### DIFF
--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -15,9 +15,131 @@ import sys
 import numpy as np
 import pandas
 import rospkg
+import yaml
 
+import robot_interfaces
 import robot_fingers
 import trifinger_object_tracking.py_tricamera_types as tricamera
+
+
+# Distance from the zero position (finger pointing straight down) to the
+# end-stop.  This is independent of the placement of the encoder disc and
+# thus should be the same on all TriFingerPro robots.
+# TODO: this should actually be the same for all three fingers!  Needs to
+#       be fixed in the calibration script, though.
+_zero_to_endstop = np.array(
+    [2.112, 2.399, -2.714, 2.118, 2.471, -2.694, 2.179, 2.456, -2.723]
+)
+
+# Torque used to find end-stop during homing
+# TODO: this could be read from the config file
+_homing_torque = [+0.3, +0.3, -0.2] * 3
+
+# Maximum torque with signs same as for end-stop search
+_max_torque_against_homing_endstop = [+0.4, +0.4, -0.4] * 3
+
+# Tolerance when checking if expected position is reached
+_position_tolerance = 0.1
+
+
+def get_robot_config(
+    position_limits=True,
+    robot_config_file="/etc/trifingerpro/trifingerpro.yml",
+) -> str:
+    """Get path to robot configuration file.
+
+    This may be the file specified by robot_config_file or a temporary copy
+    with modifications, based on other arguments.
+
+    Args:
+        position_limits:  If True, the original configuration is used with the
+            position limits as they are defined there.  If false, a temporary
+            configuration file is created where the position limits are
+            removed.
+        robot_config_file:  Path to the original robot configuration file.
+    """
+    if position_limits:
+        return robot_config_file
+    else:
+        with open(robot_config_file, "r") as fh:
+            config = yaml.load(fh)
+
+        # remove position limits
+        config["hard_position_limits_lower"] = [-np.inf] * 9
+        config["hard_position_limits_upper"] = [+np.inf] * 9
+        del config["soft_position_limits_lower"]
+        del config["soft_position_limits_upper"]
+
+        tmp_config_file = "/tmp/trifingerpro.yml"
+        with open(tmp_config_file, "w") as fh:
+            yaml.dump(config, fh)
+
+        return tmp_config_file
+
+
+def end_stop_check(robot: robot_fingers.Robot):
+    """Move robot to endstop, using constant torque and verify its position.
+
+    Applies a constant torque for a fixed time to move to the end-stop.  If
+    everything is okay, the robot should be at the end-stop position after this
+    time.  If it is not, trigger a fault.
+
+    Then move back to the initial position in a controlled way and again verify
+    that the goal was reached successfully.
+
+    Args:
+        robot:  Initialized robot instance of the TriFingerPro.
+    """
+    # go to the "homing" end-stop
+    action = robot.Action(torque=_homing_torque)
+    for _ in range(2000):
+        t = robot.frontend.append_desired_action(action)
+        robot.frontend.wait_until_timeindex(t)
+
+    # push with maximum torque for a moment for slipping joint detection
+    action = robot.Action(torque=_max_torque_against_homing_endstop)
+    for _ in range(1000):
+        t = robot.frontend.append_desired_action(action)
+        robot.frontend.wait_until_timeindex(t)
+
+    # release motors, so the joints are not actively pushing against the
+    # end-stop anymore
+    action = robot.Action()
+    for _ in range(500):
+        t = robot.frontend.append_desired_action(action)
+        robot.frontend.wait_until_timeindex(t)
+
+    observation = robot.frontend.get_observation(t)
+
+    if (
+        np.linalg.norm(_zero_to_endstop - observation.position)
+        > _position_tolerance
+    ):
+        print("End stop not at expected position.")
+        print("Expected position: {}".format(_zero_to_endstop))
+        print("Actual position: {}".format(observation.position))
+        sys.exit(1)
+
+    # move back joint-by-joint
+    goals = [
+        (1000, np.array([0, np.nan, np.nan] * 3)),
+        (500, np.array([0, 1.1, np.nan] * 3)),
+        (500, np.array([0, 1.1, -1.9] * 3)),
+    ]
+    for duration, goal in goals:
+        action = robot.Action(position=goal)
+        for _ in range(duration):
+            t = robot.frontend.append_desired_action(action)
+            robot.frontend.wait_until_timeindex(t)
+
+    observation = robot.frontend.get_observation(t)
+
+    # verify that goal is reached
+    if np.linalg.norm(goal - observation.position) > _position_tolerance:
+        print("Robot did not reach goal position")
+        print("Desired position: {}".format(goal))
+        print("Actual position: {}".format(observation.position))
+        sys.exit(1)
 
 
 def run_self_test(robot):
@@ -27,9 +149,7 @@ def run_self_test(robot):
     initial_pose = [0, 1.1, -1.9] * 3
 
     reachable_goals = [
-        [0.75, 1.2, -2.3] * 3,
         [0.9, 1.5, -2.6] * 3,
-        initial_pose,
         [-0.3, 1.5, -1.7] * 3,
     ]
 
@@ -121,9 +241,7 @@ def check_if_cube_is_there():
     camera_driver = tricamera.TriCameraObjectTrackerDriver(
         "camera60", "camera180", "camera300"
     )
-    camera_backend = tricamera.Backend(  # noqa
-        camera_driver, camera_data
-    )
+    camera_backend = tricamera.Backend(camera_driver, camera_data)  # noqa
     camera_frontend = tricamera.Frontend(camera_data)
 
     observation = camera_frontend.get_latest_observation()
@@ -135,15 +253,27 @@ def check_if_cube_is_there():
 
 
 def main():
-    robot = robot_fingers.Robot.create_by_name("trifingerpro")
+    config_file = get_robot_config(position_limits=False)
+
+    # robot = robot_fingers.Robot.create_by_name("trifingerpro")
+    robot = robot_fingers.Robot(
+        robot_interfaces.trifinger,
+        robot_fingers.create_trifinger_backend,
+        config_file,
+    )
     robot.initialize()
 
+    print("End stop test")
+    end_stop_check(robot)
+    print("Position reachability test")
     run_self_test(robot)
+    print("Reset cube position")
     shuffle_cube(robot)
 
     # terminate the robot
     del robot
 
+    print("Check if cube is found")
     check_if_cube_is_there()
 
 


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

This is the script that gets executed automatically after each submission.

Add a test that moves to the end-stop and verifies its position.  To be able to move there, the position limits need to be disabled.  Do this by creating a temporary config file based on the normal robots configuration.

With this test, we should be able to auto-detect bad offset calibration.  Further, it should also detect slipping joints (if a joint slips, it would still move after reaching the end-stop and thus the resulting position would be wrong).

To compensate a bit for the additional time this test takes, I removed two target positions from the following test (`run_self_test`).  I am actually a bit unsure if with the end-stop test, the old `run_self_test()` still adds any value.  Maybe it could be removed completely.

## How I Tested

By running it multiple times on TriFingerPro 2.

See also [this video](https://nextcloud.tuebingen.mpg.de/index.php/s/RfKPkT3peEGQBQ8) (the new `end_stop_check()` is executed from 00:17 to 00:23).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
