### PR TITLE
Add option for "first action timeout" in backend

### DIFF
--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -2,6 +2,7 @@
 """Run TriFinger back-end using multi-process robot data."""
 import argparse
 import logging
+import math
 import pathlib
 import sys
 
@@ -18,6 +19,15 @@ def main():
         required=True,
         help="""Maximum numbers of actions that are processed.  After this the
             backend shuts down automatically.
+        """,
+    )
+    parser.add_argument(
+        "--first-action-timeout",
+        "-t",
+        type=float,
+        default=math.inf,
+        help="""Timeout (in seconds) for reception of first action after
+            starting the backend.  If not set, the timeout is disabled.
         """,
     )
     parser.add_argument(
@@ -92,6 +102,7 @@ def main():
     backend = robot_fingers.create_trifinger_backend(
         robot_data,
         config_file_path,
+        first_action_timeout=args.first_action_timeout,
         max_number_of_actions=args.max_number_of_actions,
     )
 


### PR DESCRIPTION
## Description

Add option to `trifinger_backend.py` to set `first_action_timeout` of the RobotBackend.
The timeout stops the backend if the user does not provided the first action within the specified number of seconds after the backend was started.  This is needed for the submission system setup to avoid that the backend waits forever in case the user does not sent an action (e.g. because their script crashes during initialization).


## How I Tested

With the submission system setup on TriFingerPro 2.

## Do not merge before

- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/85

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
