### PR TITLE
Exit with non-zero code if back end terminated with failure

### DIFF
--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -137,7 +137,8 @@ def main():
         camera_logger.start()
         logging.info("Start camera logging")
 
-    backend.wait_until_terminated()
+    termination_reason = backend.wait_until_terminated()
+    logging.debug("Backend termination reason: %d", termination_reason)
 
     # delete the ready indicator file to indicate that the backend has shut
     # down
@@ -161,6 +162,13 @@ def main():
             args.robot_logfile, start_index=0, end_index=end_index
         )
 
+    if termination_reason < 0:
+        # negate code as exit codes should be positive
+        return -termination_reason
+    else:
+        return 0
+
 
 if __name__ == "__main__":
-    main()
+    returncode = main()
+    sys.exit(returncode)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Exit with non-zero code if back end terminated with failure


## How I Tested

With the submission system setup on roboch2.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/87

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
