### PR TITLE
Option to use camera driver with or without object tracking

### DIFF
--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -32,10 +32,14 @@ def main():
     )
     camera_group = parser.add_mutually_exclusive_group()
     camera_group.add_argument(
-        "--cameras", "-c", action="store_true", help="Run camera backend.",
+        "--cameras",
+        "-c",
+        action="store_true",
+        help="Run camera backend.",
     )
     camera_group.add_argument(
-        "--cameras-with-tracker", action="store_true",
+        "--cameras-with-tracker",
+        action="store_true",
         help="Run camera backend with integrated object tracker.",
     )
     parser.add_argument(
@@ -66,17 +70,19 @@ def main():
     logging.basicConfig(
         format="[TRIFINGER_BACKEND %(levelname)s %(asctime)s] %(message)s",
         level=logging.DEBUG,
-        handlers=[log_handler]
+        handlers=[log_handler],
     )
 
     cameras_enabled = False
     if args.cameras:
         cameras_enabled = True
         from trifinger_cameras import tricamera
+
         CameraDriver = tricamera.TriCameraDriver
     elif args.cameras_with_tracker:
         cameras_enabled = True
         import trifinger_object_tracking.py_tricamera_types as tricamera
+
         CameraDriver = tricamera.TriCameraObjectTrackerDriver
 
     if cameras_enabled:
@@ -89,9 +95,7 @@ def main():
             "tricamera", True, CAMERA_TIME_SERIES_LENGTH
         )
         camera_driver = CameraDriver("camera60", "camera180", "camera300")
-        camera_backend = tricamera.Backend(  # noqa
-            camera_driver, camera_data
-        )
+        camera_backend = tricamera.Backend(camera_driver, camera_data)  # noqa
 
         logging.info("Camera backend ready.")
 
@@ -135,9 +139,7 @@ def main():
         log_size = int(camera_fps * episode_length_s * buffer_length_factor)
 
         logging.info("Initialize camera logger with buffer size %d", log_size)
-        camera_logger = tricamera.Logger(
-            camera_data, log_size
-        )
+        camera_logger = tricamera.Logger(camera_data, log_size)
 
     # if specified, create the "ready indicator" file to indicate that the
     # backend is ready

--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -30,8 +30,13 @@ def main():
             starting the backend.  If not set, the timeout is disabled.
         """,
     )
-    parser.add_argument(
+    camera_group = parser.add_mutually_exclusive_group()
+    camera_group.add_argument(
         "--cameras", "-c", action="store_true", help="Run camera backend.",
+    )
+    camera_group.add_argument(
+        "--cameras-with-tracker", action="store_true",
+        help="Run camera backend with integrated object tracker.",
     )
     parser.add_argument(
         "--robot-logfile",
@@ -64,9 +69,18 @@ def main():
         handlers=[log_handler]
     )
 
+    cameras_enabled = False
     if args.cameras:
-        logging.info("Start camera backend")
+        cameras_enabled = True
+        from trifinger_cameras import tricamera
+        CameraDriver = tricamera.TriCameraDriver
+    elif args.cameras_with_tracker:
+        cameras_enabled = True
         import trifinger_object_tracking.py_tricamera_types as tricamera
+        CameraDriver = tricamera.TriCameraObjectTrackerDriver
+
+    if cameras_enabled:
+        logging.info("Start camera backend")
 
         # make sure camera time series covers at least one second
         CAMERA_TIME_SERIES_LENGTH = 15
@@ -74,9 +88,7 @@ def main():
         camera_data = tricamera.MultiProcessData(
             "tricamera", True, CAMERA_TIME_SERIES_LENGTH
         )
-        camera_driver = tricamera.TriCameraObjectTrackerDriver(
-            "camera60", "camera180", "camera300"
-        )
+        camera_driver = CameraDriver("camera60", "camera180", "camera300")
         camera_backend = tricamera.Backend(  # noqa
             camera_driver, camera_data
         )
@@ -111,7 +123,7 @@ def main():
 
     logging.info("Robot backend is ready")
 
-    if args.cameras and args.camera_logfile:
+    if cameras_enabled and args.camera_logfile:
         camera_fps = 10
         robot_rate_hz = 1000
         # make the logger buffer a bit bigger as needed to be on the safe side
@@ -132,7 +144,7 @@ def main():
     if args.ready_indicator:
         pathlib.Path(args.ready_indicator).touch()
 
-    if args.cameras and args.camera_logfile:
+    if cameras_enabled and args.camera_logfile:
         backend.wait_until_first_action()
         camera_logger.start()
         logging.info("Start camera logging")
@@ -145,7 +157,7 @@ def main():
     if args.ready_indicator:
         pathlib.Path(args.ready_indicator).unlink()
 
-    if args.cameras and args.camera_logfile:
+    if cameras_enabled and args.camera_logfile:
         logging.info(
             "Save recorded camera data to file %s", args.camera_logfile
         )


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
trifinger_backend.py: Change the behaviour of `--cameras` to run the plain camera driver from trifinger_cameras and add an alternative option `--cameras-with-tracker` to run the version from trifinger_object_tracking which has the object tracker integrated.

This will be needed for the future when people work on different projects on the robots and thus it does not make sense to have an object tracker for one specific object always running in the camera backend.

## How I Tested

By running the backend with both options and comparing log files to verify that in one case the driver with and in the other case the driver without object tracker was running.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
