### PR TITLE
Fix warnings

### DIFF
--- a/src/trifinger_platform_log.cpp
+++ b/src/trifinger_platform_log.cpp
@@ -24,7 +24,8 @@ TriFingerPlatformLog::TriFingerPlatformLog(const std::string &robot_log_file,
     // missing
     for (size_t i = 0; i < robot_log_.data.size(); i++)
     {
-        if (i + robot_log_start_index_ != robot_log_.data[i].timeindex)
+        if (i + robot_log_start_index_ !=
+            static_cast<size_t>(robot_log_.data[i].timeindex))
         {
             throw std::runtime_error("Robot log is incomplete.");
         }
@@ -37,7 +38,7 @@ TriFingerPlatformLog::TriFingerPlatformLog(const std::string &robot_log_file,
         // timestamp in robot log is in seconds, convert to milliseconds
         auto stamp_robot_ms = robot_log_.data[i_robot].timestamp * 1000;
 
-        while (i_camera < camera_log_.timestamps.size() &&
+        while (static_cast<size_t>(i_camera) < camera_log_.timestamps.size() &&
                stamp_robot_ms >= camera_log_.timestamps[i_camera])
         {
             i_camera++;


### PR DESCRIPTION
## Description

Fix two "comparison between signed and unsigned" warnings by explicitly
casting to unsigned.  In both cases it should be guaranteed that the
signed part cannot be negative, so the cast should be safe.


## How I Tested

By running `demo_trifinger_platform_log`.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
