### PR TITLE
Add GitHub action to check for new TODOs in PRs

### DIFF
--- a/.github/workflows/pr_todo_checks.yml
+++ b/.github/workflows/pr_todo_checks.yml
@@ -1,0 +1,28 @@
+name: PR TODO checks
+
+on: pull_request
+
+jobs:
+  fixmes:
+    name: New FIXMEs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch origin ${GITHUB_BASE_REF}
+    - name: Check for FIXMEs
+      uses: luator/github_action_check_new_todos@v1.0.0
+      with:
+          label: FIXME
+          base_ref: origin/${{ github.base_ref }}
+
+  todos:
+    name: New TODOs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: git fetch origin ${GITHUB_BASE_REF}
+    - name: Check for TODOs
+      uses: luator/github_action_check_new_todos@v1.0.0
+      with:
+          label: TODO
+          base_ref: origin/${{ github.base_ref }}


### PR DESCRIPTION
## Description

The action is executed on pull requests and fails if new FIXMEs or TODOs
are added.


## How I Tested

In a separate test repository.