### PR TITLE
Add Python bindings for driver configuration and allow passing it instead of a file.

### DIFF
--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -467,7 +467,7 @@ public:
  *     NJointBlmcRobotDriver.
  *
  * @param robot_data  Instance of RobotData used for communication.
- * @param config_file_path  Path to the driver configuration file.
+ * @param config  Driver configuration.
  * @param first_action_timeout  Duration for which the backend waits for the
  *     first action to arrive.  If exceeded, the backend shuts down.
  * @param max_number_of_actions  Number of actions after which the backend
@@ -478,16 +478,13 @@ public:
 template <typename Driver>
 typename Driver::Types::BackendPtr create_backend(
     typename Driver::Types::BaseDataPtr robot_data,
-    const std::string &config_file_path,
+    const typename Driver::Config &config,
     const double first_action_timeout = std::numeric_limits<double>::infinity(),
     const uint32_t max_number_of_actions = 0)
 {
     constexpr double MAX_ACTION_DURATION_S = 0.003;
     constexpr double MAX_INTER_ACTION_DURATION_S = 0.005;
 
-    std::cout << "Load robot driver configuration from file '"
-              << config_file_path << "'" << std::endl;
-    auto config = Driver::Config::load_config(config_file_path);
     config.print();
 
     // wrap the actual robot driver directly in a MonitoredRobotDriver
@@ -507,6 +504,27 @@ typename Driver::Types::BackendPtr create_backend(
     backend->set_max_action_repetitions(std::numeric_limits<uint32_t>::max());
 
     return backend;
+}
+
+/**
+ * @brief Create backend using the specified driver.
+ *
+ * Overloaded version that takes a path to a configuration YAML file instead of
+ * a Config instance.
+ */
+template <typename Driver>
+typename Driver::Types::BackendPtr create_backend(
+    typename Driver::Types::BaseDataPtr robot_data,
+    const std::string &config_file_path,
+    const double first_action_timeout = std::numeric_limits<double>::infinity(),
+    const uint32_t max_number_of_actions = 0)
+{
+    std::cout << "Load robot driver configuration from file '"
+              << config_file_path << "'" << std::endl;
+    auto config = Driver::Config::load_config(config_file_path);
+
+    return create_backend<Driver>(
+        robot_data, config, first_action_timeout, max_number_of_actions);
 }
 
 }  // namespace robot_fingers

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -318,7 +318,7 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
     bool has_endstop = false;
 
     //! @brief Parameters related to calibration.
-    struct
+    struct CalibrationParameters
     {
         //! @brief Torque that is used to find the end stop.
         Vector endstop_search_torques_Nm = Vector::Zero();
@@ -335,7 +335,7 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
     Vector safety_kd = Vector::Constant(0.1);
 
     //! @brief Default control gains for the position PD controller.
-    struct
+    struct PositionControlGains
     {
         Vector kp = Vector::Zero();
         Vector kd = Vector::Zero();

--- a/srcpy/generic_driver_bindings.hpp
+++ b/srcpy/generic_driver_bindings.hpp
@@ -138,7 +138,21 @@ template <typename Driver>
 void bind_create_backend(pybind11::module &m, const std::string &name)
 {
     m.def(name.c_str(),
-          &create_backend<Driver>,
+          pybind11::overload_cast<typename Driver::Types::BaseDataPtr,
+                                  const typename Driver::Config &,
+                                  const double,
+                                  const uint32_t>(&create_backend<Driver>),
+          pybind11::arg("robot_data"),
+          pybind11::arg("config"),
+          pybind11::arg("first_action_timeout") =
+              std::numeric_limits<double>::infinity(),
+          pybind11::arg("max_number_of_actions") = 0);
+
+    m.def(name.c_str(),
+          pybind11::overload_cast<typename Driver::Types::BaseDataPtr,
+                                  const std::string &,
+                                  const double,
+                                  const uint32_t>(&create_backend<Driver>),
           pybind11::arg("robot_data"),
           pybind11::arg("config_file"),
           pybind11::arg("first_action_timeout") =

--- a/srcpy/generic_driver_bindings.hpp
+++ b/srcpy/generic_driver_bindings.hpp
@@ -1,0 +1,149 @@
+/**
+ * @file
+ * @brief Helper functions for Python-binding templated types.
+ * @copyright 2019, Max Planck Gesellschaft.  All rights reserved.
+ * @license BSD 3-clause
+ */
+#include <pybind11/eigen.h>
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+#include <robot_interfaces/n_joint_robot_types.hpp>
+
+namespace robot_fingers
+{
+template <typename Driver>
+void bind_driver_config(pybind11::module &m, const std::string &name)
+{
+    pybind11::class_<typename Driver::Config,
+                     std::shared_ptr<typename Driver::Config>>
+        config(m, name.c_str());
+    config.def(pybind11::init<>())
+        .def_static("load_config",
+                    &Driver::Config::load_config,
+                    pybind11::call_guard<pybind11::gil_scoped_release>(),
+                    pybind11::arg("config_file_name"),
+                    R"XXX(
+             load_config(config_file_name: str) -> Config
+
+             Load driver configuration from a YAML file.
+
+             Args:
+                 config_file_name:  Path to the config file.
+
+             Returns:
+                 The configuration loaded from the given file.
+)XXX")
+        .def("is_within_hard_position_limits",
+             &Driver::Config::is_within_hard_position_limits,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             pybind11::arg("position"),
+             R"XXX(
+             is_within_hard_position_limits(position: list) -> bool
+
+             Check if the given position is within the hard limits.
+
+             Args:
+                 position:  Joint positions.
+
+             Returns:
+                 True if `hard_position_limits_lower <= position <=
+                 hard_position_limits_upper`.
+)XXX")
+        .def("print",
+             &Driver::Config::print,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+             print()
+
+             Print the configuration.
+)XXX")
+        .def_readwrite("can_ports",
+                       &Driver::Config::can_ports,
+                       "List of CAN port names used by the robot.")
+        .def_readwrite("max_current_A",
+                       &Driver::Config::max_current_A,
+                       "Maximum current that can be sent to the motor [A].")
+        .def_readwrite("has_endstop",
+                       &Driver::Config::has_endstop,
+                       "Whether the joints have physical end stops or not.")
+        .def_readwrite("calibration",
+                       &Driver::Config::calibration,
+                       "Parameters related to calibration.")
+        .def_readwrite("move_to_position_tolerance_rad",
+                       &Driver::Config::move_to_position_tolerance_rad,
+                       "Tolerance for reaching the target with "
+                       "NJointBlmcRobotDriver::move_to_position()")
+        .def_readwrite(
+            "safety_kd",
+            &Driver::Config::safety_kd,
+            "D-gain to dampen velocity.  Set to zero to disable damping.")
+        .def_readwrite("position_control_gains",
+                       &Driver::Config::position_control_gains,
+                       "Default control gains for the position controller.")
+        .def_readwrite("hard_position_limits_lower",
+                       &Driver::Config::hard_position_limits_lower,
+                       "Hard lower limits for joint positions.")
+        .def_readwrite("hard_position_limits_upper",
+                       &Driver::Config::hard_position_limits_upper,
+                       "Hard upper limits for joint positions.")
+        .def_readwrite("soft_position_limits_lower",
+                       &Driver::Config::soft_position_limits_lower,
+                       "Soft lower limits for joint positions.")
+        .def_readwrite("soft_position_limits_upper",
+                       &Driver::Config::soft_position_limits_upper,
+                       "Soft upper limits for joint positions.")
+        .def_readwrite("home_offset_rad",
+                       &Driver::Config::home_offset_rad,
+                       "Offset between home and zero position.")
+        .def_readwrite(
+            "initial_position_rad",
+            &Driver::Config::initial_position_rad,
+            "Initial position to which the robot moves during initialisation.")
+        .def_readwrite("shutdown_trajectory",
+                       &Driver::Config::shutdown_trajectory,
+                       "Trajectory which is executed during shutdown.");
+
+    pybind11::class_<typename Driver::Config::TrajectoryStep>(config,
+                                                              "TrajectoryStep")
+        .def(pybind11::init<>())
+        .def_readwrite("target_position_rad",
+                       &Driver::Config::TrajectoryStep::target_position_rad,
+                       "Target position to which the joints should move.")
+        .def_readwrite(
+            "move_steps",
+            &Driver::Config::TrajectoryStep::move_steps,
+            "Number of time steps for reaching the target position.");
+
+    pybind11::class_<typename Driver::Config::CalibrationParameters>(
+        config, "CalibrationParameters")
+        .def(pybind11::init<>())
+        .def_readwrite(
+            "endstop_search_torques_Nm",
+            &Driver::Config::CalibrationParameters::endstop_search_torques_Nm,
+            "Torque that is used to find the end stop.")
+        .def_readwrite(
+            "move_steps",
+            &Driver::Config::CalibrationParameters::move_steps,
+            "Number of time steps for reaching the initial position.");
+
+    pybind11::class_<typename Driver::Config::PositionControlGains>(
+        config, "PositionControlGains")
+        .def(pybind11::init<>())
+        .def_readwrite("kp", &Driver::Config::PositionControlGains::kp)
+        .def_readwrite("kd", &Driver::Config::PositionControlGains::kd);
+}
+
+template <typename Driver>
+void bind_create_backend(pybind11::module &m, const std::string &name)
+{
+    m.def(name.c_str(),
+          &create_backend<Driver>,
+          pybind11::arg("robot_data"),
+          pybind11::arg("config_file"),
+          pybind11::arg("first_action_timeout") =
+              std::numeric_limits<double>::infinity(),
+          pybind11::arg("max_number_of_actions") = 0);
+}
+
+}  // namespace robot_fingers

--- a/srcpy/py_one_joint.cpp
+++ b/srcpy/py_one_joint.cpp
@@ -14,23 +14,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#include <pybind11/eigen.h>
-#include <pybind11/embed.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl_bind.h>
 
 #include <robot_fingers/one_joint_driver.hpp>
 
-using namespace pybind11::literals;
+#include "generic_driver_bindings.hpp"
+
 using namespace robot_fingers;
 
 PYBIND11_MODULE(py_one_joint, m)
 {
-    m.def("create_one_joint_backend",
-          &create_backend<OneJointDriver>,
-          "robot_data"_a,
-          "config_file"_a,
-          "first_action_timeout"_a = std::numeric_limits<double>::infinity(),
-          "max_number_of_actions"_a = 0);
+    bind_create_backend<OneJointDriver>(m, "create_one_joint_backend");
+    bind_driver_config<OneJointDriver>(m, "OneJointConfig");
 }

--- a/srcpy/py_real_finger.cpp
+++ b/srcpy/py_real_finger.cpp
@@ -14,26 +14,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#include <pybind11/eigen.h>
-#include <pybind11/embed.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl_bind.h>
 
 #include <robot_fingers/fake_finger_driver.hpp>
 #include <robot_fingers/real_finger_driver.hpp>
 
-using namespace pybind11::literals;
+#include "generic_driver_bindings.hpp"
+
 using namespace robot_fingers;
 
 PYBIND11_MODULE(py_real_finger, m)
 {
-    m.def("create_real_finger_backend",
-          &create_backend<RealFingerDriver>,
-          "robot_data"_a,
-          "config_file"_a,
-          "first_action_timeout"_a = std::numeric_limits<double>::infinity(),
-          "max_number_of_actions"_a = 0);
+    bind_create_backend<RealFingerDriver>(m, "create_real_finger_backend");
+    bind_driver_config<RealFingerDriver>(m, "FingerConfig");
 
     m.def("create_fake_finger_backend", &create_fake_finger_backend);
 }

--- a/srcpy/py_trifinger.cpp
+++ b/srcpy/py_trifinger.cpp
@@ -24,6 +24,8 @@
 #include <robot_fingers/trifinger_platform_frontend.hpp>
 #include <robot_fingers/trifinger_platform_log.hpp>
 
+#include "generic_driver_bindings.hpp"
+
 using namespace pybind11::literals;
 using namespace robot_fingers;
 
@@ -37,12 +39,8 @@ PYBIND11_MODULE(py_trifinger, m)
     // needed for bindings of camera observations
     pybind11::module::import("trifinger_object_tracking.py_tricamera_types");
 
-    m.def("create_trifinger_backend",
-          &create_backend<TriFingerDriver>,
-          "robot_data"_a,
-          "config_file"_a,
-          "first_action_timeout"_a = std::numeric_limits<double>::infinity(),
-          "max_number_of_actions"_a = 0);
+    bind_create_backend<TriFingerDriver>(m, "create_trifinger_backend");
+    bind_driver_config<TriFingerDriver>(m, "TriFingerConfig");
 
     pybind11::class_<TriFingerPlatformFrontend,
                      std::shared_ptr<TriFingerPlatformFrontend>>(

--- a/srcpy/py_two_joint.cpp
+++ b/srcpy/py_two_joint.cpp
@@ -14,23 +14,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-#include <pybind11/eigen.h>
-#include <pybind11/embed.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl_bind.h>
 
 #include <robot_fingers/two_joint_driver.hpp>
 
-using namespace pybind11::literals;
+#include "generic_driver_bindings.hpp"
+
 using namespace robot_fingers;
 
 PYBIND11_MODULE(py_two_joint, m)
 {
-    m.def("create_two_joint_backend",
-          &create_backend<TwoJointDriver>,
-          "robot_data"_a,
-          "config_file"_a,
-          "first_action_timeout"_a = std::numeric_limits<double>::infinity(),
-          "max_number_of_actions"_a = 0);
+    bind_create_backend<TwoJointDriver>(m, "create_two_joint_backend");
+    bind_driver_config<TwoJointDriver>(m, "TwoJointConfig");
 }


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add Python bindings for the robot driver configuration and overload `create_backend` such that a `Config` object can be passed instead of a file.

Allows for more flexible configuration (e.g. the CAN ports from the config file could be overwritten by an argument passed to the script). This is especially useful for debugging and hardware testing tools where one might want to try out different settings.


## How I Tested

- Running demos on FingerOne and TriFingerPro to verify that normal loading from file still works.
- Modified demos to pass a custom config and verified that this works as expected.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
