### PR TITLE
implemented homing at endstops

### DIFF
--- a/config/twojoint.yml
+++ b/config/twojoint.yml
@@ -4,6 +4,7 @@ can_ports: ["can6"]
 
 max_current_A: 2
 has_endstop: true
+homing_at_endstop: true
 move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22]

--- a/config/twojoint.yml
+++ b/config/twojoint.yml
@@ -4,7 +4,7 @@ can_ports: ["can6"]
 
 max_current_A: 2
 has_endstop: true
-homing_at_endstop: true
+# homing_with_index: false
 move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22]

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -88,12 +88,24 @@ public:
      */
     const bool has_endstop_;
 
+    /**
+     * @brief True if end-stops are used to define zero positions 
+     *
+     * If set to true, has_endstop has to be true as well
+     *
+     * If present, the end stops are used for a fully automated homing procedure
+     * in which the joints move until they hit the end stop. This position
+     * will then be used to define the new zero position.
+     */
+    const bool homing_at_endstop_;
+
     NJointBlmcRobotDriver(const MotorBoards &motor_boards,
                           const Motors &motors,
                           const MotorParameters &motor_parameters,
                           const Config &config)
         : robot_interfaces::RobotDriver<Action, Observation>(),
           has_endstop_(config.has_endstop),
+          homing_at_endstop_(config.homing_at_endstop),
           joint_modules_(motors,
                          motor_parameters.torque_constant_NmpA * Vector::Ones(),
                          motor_parameters.gear_ratio * Vector::Ones(),
@@ -316,6 +328,16 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
      * rotate freely in general.
      */
     bool has_endstop = false;
+
+    /**
+     * @brief Whether the end stop positions should be used to define the zero
+     * position of the joints
+     *
+     * This is for example relevant for homing, where (in case this value
+     * is set to true) all joints move until they hit the end stop to
+     * determine their absolute position.
+     */
+    bool homing_at_endstop = false;
 
     //! @brief Parameters related to calibration.
     struct CalibrationParameters

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -327,7 +327,7 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
      * @brief Whether the next index position should be used to define the zero
      * position of the joints
      */
-    bool homing_with_index = false;
+    bool homing_with_index = true;
 
     //! @brief Parameters related to calibration.
     struct CalibrationParameters

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -89,15 +89,9 @@ public:
     const bool has_endstop_;
 
     /**
-     * @brief True if end-stops are used to define zero positions 
-     *
-     * If set to true, has_endstop has to be true as well
-     *
-     * If present, the end stops are used for a fully automated homing procedure
-     * in which the joints move until they hit the end stop. This position
-     * will then be used to define the new zero position.
+     * @brief If true, use next index position to define zero positions 
      */
-    const bool homing_at_endstop_;
+    const bool homing_with_index_;
 
     NJointBlmcRobotDriver(const MotorBoards &motor_boards,
                           const Motors &motors,
@@ -105,7 +99,7 @@ public:
                           const Config &config)
         : robot_interfaces::RobotDriver<Action, Observation>(),
           has_endstop_(config.has_endstop),
-          homing_at_endstop_(config.homing_at_endstop),
+          homing_with_index_(config.homing_with_index),
           joint_modules_(motors,
                          motor_parameters.torque_constant_NmpA * Vector::Ones(),
                          motor_parameters.gear_ratio * Vector::Ones(),
@@ -330,14 +324,10 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
     bool has_endstop = false;
 
     /**
-     * @brief Whether the end stop positions should be used to define the zero
+     * @brief Whether the next index position should be used to define the zero
      * position of the joints
-     *
-     * This is for example relevant for homing, where (in case this value
-     * is set to true) all joints move until they hit the end stop to
-     * determine their absolute position.
      */
-    bool homing_at_endstop = false;
+    bool homing_with_index = false;
 
     //! @brief Parameters related to calibration.
     struct CalibrationParameters

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hxx
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hxx
@@ -694,7 +694,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
         // Homing at endstop
 
         homing_status =
-            joint_modules_.execute_homing_at_endstop(home_offset_rad);
+            joint_modules_.execute_homing_at_current_position(home_offset_rad);
 
         rt_printf("Finished homing at endstops");
 

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hxx
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hxx
@@ -30,7 +30,7 @@ void NJBRD::Config::print() const
     std::cout << "\n"
               << "\t max_current_A: " << max_current_A << "\n"
               << "\t has_endstop: " << has_endstop << "\n"
-              << "\t homing_at_endstop: " << homing_at_endstop << "\n"
+              << "\t homing_with_index: " << homing_with_index << "\n"
               << "\t move_to_position_tolerance_rad: "
               << move_to_position_tolerance_rad << "\n"
               << "\t calibration:\n"
@@ -115,7 +115,12 @@ typename NJBRD::Config NJBRD::Config::load_config(
 
     set_config_value(user_config, "max_current_A", &config.max_current_A);
     set_config_value(user_config, "has_endstop", &config.has_endstop);
-    set_config_value(user_config, "homing_at_endstop", &config.homing_at_endstop);
+
+    if (user_config["homing_with_index"])
+    {
+        set_config_value(user_config, "homing_with_index", &config.homing_with_index);
+    }
+
     set_config_value(user_config,
                      "move_to_position_tolerance_rad",
                      &config.move_to_position_tolerance_rad);
@@ -653,17 +658,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
 
     blmc_drivers::HomingReturnCode homing_status = blmc_drivers::HomingReturnCode::NOT_INITIALIZED;
 
-    if (homing_at_endstop_)
-    {
-        // Homeing at endstop
-
-        homing_status =
-            joint_modules_.execute_homing_at_endstop(home_offset_rad);
-
-        rt_printf("Finished homing at endstops");
-
-    }
-    else
+    if (homing_with_index_)
     {
         // Home on encoder index
 
@@ -693,6 +688,16 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
             rt_printf("%.3f, ", -travelled_distance[i]);
         }
         rt_printf("\n");
+    }
+    else
+    {
+        // Homing at endstop
+
+        homing_status =
+            joint_modules_.execute_homing_at_endstop(home_offset_rad);
+
+        rt_printf("Finished homing at endstops");
+
     }
 
     return homing_status == blmc_drivers::HomingReturnCode::SUCCEEDED;


### PR DESCRIPTION
## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."

Added homing at end-stop as an additional homing procedure. 
In this mode, the end-stop position will be used to define zero.  

## How I Tested

Tested with twojoint.yml

## Do not merge before

## I fulfilled the following requirements

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
