### PR TITLE
Joint Friction Calibration: Make CAN port configurable

### DIFF
--- a/config/onejoint_friction_calibration.yml
+++ b/config/onejoint_friction_calibration.yml
@@ -5,6 +5,7 @@ can_ports: ["can7"]
 
 max_current_A: 2
 has_endstop: false
+homing_with_index: false
 move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22]
@@ -19,4 +20,3 @@ initial_position_rad: [0]
 
 hard_position_limits_lower: [-.inf]
 hard_position_limits_upper: [.inf]
-

--- a/config/onejoint_friction_calibration.yml
+++ b/config/onejoint_friction_calibration.yml
@@ -10,7 +10,7 @@ move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22]
     move_steps: 500
-safety_kd: [0.02]
+safety_kd: [0]
 position_control_gains:
     kp: [6]
     kd: [0.03]

--- a/scripts/joint_friction_calibration.py
+++ b/scripts/joint_friction_calibration.py
@@ -10,7 +10,6 @@ See `--help` for options.
 """
 
 import argparse
-import copy
 import curses
 import os
 import time
@@ -165,7 +164,13 @@ def run_application(stdscr, robot, velocity_radps, buffer_size):
 
 
 def main():
-    argparser = argparse.ArgumentParser()
+    argparser = argparse.ArgumentParser(description=__doc__)
+    argparser.add_argument(
+        "--canport",
+        type=str,
+        required=True,
+        help="The CAN port to which the joint is connected (e.g. 'can0').",
+    )
     argparser.add_argument(
         "--velocity",
         type=float,
@@ -187,10 +192,10 @@ def main():
         "onejoint_friction_calibration.yml",
     )
 
+    config = robot_fingers.OneJointConfig.load_config(config_file_path)
+    config.can_ports = [args.canport]
     robot_data = one_joint.SingleProcessData()
-    robot_backend = robot_fingers.create_one_joint_backend(
-        robot_data, config_file_path
-    )
+    robot_backend = robot_fingers.create_one_joint_backend(robot_data, config)
     robot_frontend = one_joint.Frontend(robot_data)
 
     robot_backend.initialize()


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add an argument to joint_friction_calibration.py to specify the CAN
port.  This way, there is no need to have this fixed or to modify it in
the config file.

Further set the new `homing_with_index` setting to basically skip the
homing (it is not need here) and disable velocity damping.

## How I Tested

By running it.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
