### PR TITLE
fix single_finger_test

### DIFF
--- a/config/single_finger_test.yml
+++ b/config/single_finger_test.yml
@@ -1,6 +1,7 @@
 can_ports: ["can0", "can1"]
 max_current_A: 2
 has_endstop: false
+homing_with_index: false
 move_to_position_tolerance_rad: 0.05
 calibration:
     endstop_search_torques_Nm: [-0.22, -0.22, -0.22]

--- a/scripts/single_finger_test.py
+++ b/scripts/single_finger_test.py
@@ -109,7 +109,7 @@ class CursesGUI:
             )
             line += 1
             self.win.addstr(
-                line, 0, "Error Message: {}".format(status.error_message)
+                line, 0, "Error Message: {}".format(status.get_error_message())
             )
             line += 1
             self.win.addstr(line, 0, "━" * 40)


### PR DESCRIPTION
## Description

- use status.get_error_message(): `error_message` has been made private recently and is only accessible through the new getter method now.
- @luator
single_finger_test: Home without index: In the single finger test application, there is no absolute position needed.  It was already homing without end-stops.  By also ignoring the encoder index, we get rid of the unnecessary motion of the joints during
initialisation.


## How I Tested

By running it


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
