### PR TITLE
Add config "homing_method" and add method "endstop_release

### DIFF
--- a/config/trifingerpro.yml
+++ b/config/trifingerpro.yml
@@ -1,6 +1,10 @@
 can_ports: ["can0", "can1", "can2", "can3", "can4", "can5"]
 max_current_A: 2.2
 has_endstop: true
+
+homing_method: endstop_release
+home_offset_rad: [-2.136, -2.442, +2.710, -2.136, -2.442, +2.710, -2.136, -2.442, +2.710]
+
 move_to_position_tolerance_rad: 0.1
 calibration:
     endstop_search_torques_Nm:
@@ -74,8 +78,6 @@ soft_position_limits_upper:
     - 1.0
     - 1.57
     - 0.0
-
-home_offset_rad: [0, 0, 0, 0, 0, 0, 0, 0, 0]
 
 # Set the initial position such that it is still save when the stage is at the
 # highest level.

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -235,23 +235,21 @@ protected:
     void move_until_blocking(Vector torques_Nm);
 
     /**
-     * @brief Homing using end stops (optional) and encoder indices.
+     * @brief Run homing of all joints.
      *
      * Procedure for finding an absolute zero position (or "home" position) when
      * using relative encoders.
      *
-     * If the robot has end stops (according to configuration), all joints first
-     * move in negative direction until they hit the end stop.
-     * Then an encoder index search is started where each joint moves slowly in
-     * positive direction until the next encoder index.  The position of this
-     * encoder index is the "home position".
+     * The method for finding the home position is depending on the
+     * "homing_method" setting in the configuration.  See @ref
+     * Config::HomingMethod for the different options.
      *
      * By default, the zero position after homing is the same as the home
      * position.  The optional argument home_offset_rad provides a means to move
      * the zero position relative to the home position.  The zero position is
      * computed as
      *
-     *     zero position = encoder index position + home offset
+     *     zero position = home position + home offset
      *
      *
      * @param endstop_search_torques_Nm Torques that are used to move the joints

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -89,7 +89,7 @@ public:
     const bool has_endstop_;
 
     /**
-     * @brief If true, use next index position to define zero positions 
+     * @brief If true, use next index position to define zero positions
      */
     const bool homing_with_index_;
 
@@ -231,6 +231,16 @@ protected:
     void _initialize();
 
     /**
+     * @brief Move with constant torque until all joints are blocking.
+     *
+     * Applies a constant torque until all joints are reporting a velocity close
+     * to zero.  This can be used to move against the end-stops.
+     *
+     * @param torques_Nm Torques that are applied to the joints.
+     */
+    void move_until_blocking(Vector torques_Nm);
+
+    /**
      * @brief Homing using end stops (optional) and encoder indices.
      *
      * Procedure for finding an absolute zero position (or "home" position) when
@@ -242,10 +252,10 @@ protected:
      * positive direction until the next encoder index.  The position of this
      * encoder index is the "home position".
      *
-     * By default, the zero position is the same as the home position.  The
-     * optional argument home_offset_rad provides a means to move the zero
-     * position
-     * relative to the home position.  The zero position is computed as
+     * By default, the zero position after homing is the same as the home
+     * position.  The optional argument home_offset_rad provides a means to move
+     * the zero position relative to the home position.  The zero position is
+     * computed as
      *
      *     zero position = encoder index position + home offset
      *
@@ -257,6 +267,37 @@ protected:
      */
     bool homing(Vector endstop_search_torques_Nm,
                 Vector home_offset_rad = Vector::Zero());
+
+    /**
+     * @brief Homing using stable end stops.
+     *
+     * Alternative homing procedure consisting of the following steps:
+     *
+     * 1. Move to the end stops.
+     * 2. Release joints (i.e. apply zero torque), so they are not actively
+     *    pushing anymore.
+     * 3. Home at the position that has been reached.
+     *
+     * This requires the robot to have "stable" end-stops, i.e. a joint is at
+     * the end-stop and the torque is set to zero, it should not move away on
+     * its own.
+     *
+     * By default, the zero position after homing is the same as the home
+     * position.  The optional argument home_offset_rad provides a means to move
+     * the zero position relative to the home position.  The zero position is
+     * computed as
+     *
+     *     zero position = encoder index position + home offset
+     *
+     *
+     * @see homing()
+     * @param endstop_search_torques_Nm Torques that are used to move the joints
+     *     while searching the end stop.
+     * @param home_offset_rad Offset between the home position and the desired
+     *     zero position.
+     */
+    void home_at_stable_endstop(Vector endstop_search_torques_Nm,
+                                Vector home_offset_rad);
 
     /**
      * @brief Move to given goal position with a minimum jerk trajectory.

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -235,30 +235,27 @@ protected:
     void move_until_blocking(Vector torques_Nm);
 
     /**
-     * @brief Run homing of all joints.
+     * @brief Homing of all joints, based on the robot configuration.
      *
-     * Procedure for finding an absolute zero position (or "home" position) when
-     * using relative encoders.
+     * Procedure for finding an absolute zero position when using relative
+     * encoders.
      *
      * The method for finding the home position is depending on the
      * "homing_method" setting in the configuration.  See @ref
      * Config::HomingMethod for the different options.
      *
      * By default, the zero position after homing is the same as the home
-     * position.  The optional argument home_offset_rad provides a means to move
-     * the zero position relative to the home position.  The zero position is
+     * position.  The optional configuration parameter @ref
+     * Config::home_offset_rad provides a means to move the zero position
+     * relative to the home position.  The zero position is
      * computed as
      *
      *     zero position = home position + home offset
      *
-     *
-     * @param endstop_search_torques_Nm Torques that are used to move the joints
-     *     while searching the end stop.
-     * @param home_offset_rad Offset between the home position and the desired
-     *     zero position.
+     * @returns True if the homing was successful, false if not.  In case of a
+     *     failure, an error message with more information is printed to stdout.
      */
-    bool homing(Vector endstop_search_torques_Nm,
-                Vector home_offset_rad = Vector::Zero());
+    bool homing();
 
     /**
      * @brief Move to given goal position with a minimum jerk trajectory.

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hxx
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hxx
@@ -677,8 +677,16 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
             if (!has_endstop_)
             {
                 rt_printf(
-                    "Selected homing method needs endstop but 'has_endstop' is "
-                    "false.");
+                    "Invalid config: Selected homing method needs endstop but "
+                    "'has_endstop' is false.");
+                return false;
+            }
+
+            if (endstop_search_torques_Nm.isZero())
+            {
+                rt_printf(
+                    "Invalid config: A homing method with end-stop search is "
+                    "selected but 'endstop_search_torques_Nm' is zero.");
                 return false;
             }
 
@@ -713,6 +721,17 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
                 (1.5 / motor_parameters_.gear_ratio) * 2 * M_PI;
             //! Absolute step size when moving for encoder index search.
             constexpr double INDEX_SEARCH_STEP_SIZE_RAD = 0.0003;
+
+            if (endstop_search_torques_Nm.isZero())
+            {
+                rt_printf(
+                    "Invalid config: A homing method with index search is "
+                    "selected but 'endstop_search_torques_Nm' is zero.  The "
+                    "sign of 'endstop_search_torques_Nm' is used to determine "
+                    "the index search direction (opposite direction to end "
+                    "stop search).");
+                return false;
+            }
 
             // Set the search direction for each joint opposite to the end-stop
             // search direction.

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hxx
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hxx
@@ -590,8 +590,7 @@ void NJBRD::_initialize()
     joint_modules_.set_position_control_gains(
         config_.position_control_gains.kp, config_.position_control_gains.kd);
 
-    bool homing_succeeded = homing(
-        config_.calibration.endstop_search_torques_Nm, config_.home_offset_rad);
+    bool homing_succeeded = homing();
     pause_motors();
 
     // NOTE: do not set is_initialized_ yet as we want to allow move_to_position
@@ -662,8 +661,7 @@ void NJBRD::move_until_blocking(NJBRD::Vector torques_Nm)
 }
 
 TPL_NJBRD
-bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
-                   NJBRD::Vector home_offset_rad)
+bool NJBRD::homing()
 {
     rt_printf("Start homing.\n");
 
@@ -682,7 +680,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
                 return false;
             }
 
-            if (endstop_search_torques_Nm.isZero())
+            if (config_.calibration.endstop_search_torques_Nm.isZero())
             {
                 rt_printf(
                     "Invalid config: A homing method with end-stop search is "
@@ -690,7 +688,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
                 return false;
             }
 
-            move_until_blocking(endstop_search_torques_Nm);
+            move_until_blocking(config_.calibration.endstop_search_torques_Nm);
             rt_printf("Reached end stop.\n");
 
             break;
@@ -722,7 +720,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
             //! Absolute step size when moving for encoder index search.
             constexpr double INDEX_SEARCH_STEP_SIZE_RAD = 0.0003;
 
-            if (endstop_search_torques_Nm.isZero())
+            if (config_.calibration.endstop_search_torques_Nm.isZero())
             {
                 rt_printf(
                     "Invalid config: A homing method with index search is "
@@ -739,7 +737,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
             for (unsigned int i = 0; i < N_JOINTS; i++)
             {
                 index_search_step_sizes[i] = INDEX_SEARCH_STEP_SIZE_RAD;
-                if (endstop_search_torques_Nm[i] > 0)
+                if (config_.calibration.endstop_search_torques_Nm[i] > 0)
                 {
                     index_search_step_sizes[i] *= -1;
                 }
@@ -747,7 +745,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
 
             homing_status =
                 joint_modules_.execute_homing(INDEX_SEARCH_DISTANCE_LIMIT_RAD,
-                                              home_offset_rad,
+                                              config_.home_offset_rad,
                                               index_search_step_sizes);
 
             break;
@@ -759,7 +757,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
             // Home at current position
 
             homing_status = joint_modules_.execute_homing_at_current_position(
-                home_offset_rad);
+                config_.home_offset_rad);
 
             break;
         }
@@ -781,7 +779,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
 
             // home at the current position (which should be at the end-stop)
             homing_status = joint_modules_.execute_homing_at_current_position(
-                home_offset_rad);
+                config_.home_offset_rad);
 
             break;
         }

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hxx
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hxx
@@ -665,9 +665,6 @@ TPL_NJBRD
 bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
                    NJBRD::Vector home_offset_rad)
 {
-    //! Distance travelled during homing (useful for home offset calibration)
-    Vector travelled_distance = Vector::Zero();
-
     rt_printf("Start homing.\n");
 
     // First move to end-stop if this is required by the selected homing method.
@@ -685,14 +682,8 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
                 return false;
             }
 
-            Vector start_position = get_latest_observation().position;
-
             move_until_blocking(endstop_search_torques_Nm);
             rt_printf("Reached end stop.\n");
-
-            // compute distance travelled during end-stop search
-            travelled_distance +=
-                get_latest_observation().position - start_position;
 
             break;
         }
@@ -740,18 +731,6 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
                                               home_offset_rad,
                                               index_search_step_sizes);
 
-            rt_printf(
-                "Finished homing.  Offset between end and start position: ");
-            travelled_distance +=
-                joint_modules_.get_distance_travelled_during_homing();
-            for (size_t i = 0; i < N_JOINTS; i++)
-            {
-                // negate the travelled distance so the output can directly be
-                // used as home offset
-                rt_printf("%.3f, ", -travelled_distance[i]);
-            }
-            rt_printf("\n");
-
             break;
         }
 
@@ -763,7 +742,6 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
             homing_status = joint_modules_.execute_homing_at_current_position(
                 home_offset_rad);
 
-            rt_printf("Finished homing at endstops");
             break;
         }
 
@@ -790,6 +768,7 @@ bool NJBRD::homing(NJBRD::Vector endstop_search_torques_Nm,
         }
     }
 
+    rt_printf("Finished homing.");
     return homing_status == blmc_drivers::HomingReturnCode::SUCCEEDED;
 }
 


### PR DESCRIPTION
## Description

### Homing Method

Add a new configuration parameter "homing_method" to specify the
homing method.  This makes "homing_with_index" obsolete and the latter
will cause an error from now on (so users see that they should update
their config).

Possible homing methods are:

#### NONE
Do not perform any homing, i.e. use the positions as reported by the motor board.  Important:  The robot will still go to the initial_position during initialisation, so this option is probably not very useful at the moment.

To use this set
```
homing_method = none
```
There is no correspondence to this option in previous versions.

#### CURRENT_POSITION
Home at current position (without moving).

To use this set
```
homing_method = current_position
```
This corresponds to the following configuration in previous versions:
```
has_endstop: false
homing_with_index: false
```

#### NEXT_INDEX
Starting from the current position, home at the next encoder index.

To use this set
```
homing_method = next_index
```
This corresponds to the following configuration in previous versions:
```
has_endstop: false
homing_with_index: true
```

#### ENDSTOP
Push against end stop and home there.

To use this set
```
homing_method = endstop
```
This corresponds to the following configuration in previous versions:
```
has_endstop: true
homing_with_index: false
```

#### ENDSTOP_INDEX
First go to end stop, then search index.

To use this set
```
homing_method = endstop_index
```
This corresponds to the following configuration in previous versions:
```
has_endstop: true
homing_with_index: true
```

#### ENDSTOP_RELEASE
Go to index, release motors (i.e. set zero torque) for a moment and home there.  This is intended for use with the TriFingerPro robots to get rid of the issue of occasionally missed encoder indices.
Important: Only use this method for robots where the end-stop-position is stable (i.e. the joints are pulled away by gravity when the torque is set to zero).

To use this set
```
homing_method = endstop_release
```
There is no correspondence to this option in previous versions.


### Other changes
- Remove the "travelled distance" output during homing. It was just bloating up the code and the output and did not bring too
much value.
- Update the configuration of TriFingerPro to use the `endstop_release` homing method.

## How I Tested

Tested all methods on a single FingerOne.  Tested `endstop_release` on a TriFingerPro.



## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
