### PR TITLE
Log run duration of the robot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,7 @@ install_scripts(
     scripts/fingeredu_endurance_test.py
     scripts/joint_friction_calibration.py
     scripts/plot_logged_data.py
+    scripts/plot_run_duration_log.py
     scripts/position_control_on_off.py
     scripts/solo_eight_backend.py
     scripts/print_position.py

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -224,6 +224,10 @@ protected:
 
     bool is_initialized_ = false;
 
+    //! \brief Counter for the number of actions sent to the robot.
+    uint32_t action_counter_ = 0;
+
+
     Action apply_action_uninitialized(const Action &desired_action);
 
     //! \brief Actual initialization that is called in a real-time thread in
@@ -400,6 +404,17 @@ struct NJointBlmcRobotDriver<Observation, N_JOINTS, N_MOTOR_BOARDS>::Config
      * to not move during shutdown.
      */
     std::vector<TrajectoryStep> shutdown_trajectory;
+
+    /**
+     * @brief List of file to which run duration logs are written.
+     *
+     * You can specify multiple files here if you want to log the runtime of
+     * different independent components separately.  For example on a robot with
+     * multiple manipulators, you can have a separate log for each manipulator,
+     * so if one of them is replaced, only the log file of this manipulator
+     * needs to be changed.
+     */
+    std::vector<std::string> run_duration_logfiles;
 
     /**
      * @brief Check if the given position is within the hard limits.

--- a/scripts/plot_run_duration_log.py
+++ b/scripts/plot_run_duration_log.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Plot the data of a given run duration log file."""
+import argparse
+import datetime
+import pathlib
+import sys
+
+import numpy as np
+import matplotlib.pyplot as plt
+import matplotlib.dates
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "logfile", type=pathlib.Path, help="Path to the logfile."
+    )
+    args = parser.parse_args()
+
+    data = np.loadtxt(args.logfile)
+
+    timestamps = [datetime.datetime.fromtimestamp(t) for t in data[:, 0]]
+    cumsum = data[:, 1].cumsum()
+
+    fig, ax = plt.subplots(1, 1)
+
+    ax.fill_between(timestamps, cumsum)
+
+    ax.set_title(args.logfile.stem)
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Accumulated Robot Run Duration [steps]")
+
+    ax.xaxis.set_major_formatter(matplotlib.dates.DateFormatter("%Y-%m-%d"))
+
+    plt.show()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add a configuration option "run_duration_logfiles" where a list of
filenames can be given.  In the shutdown method of the robot append a
line to each specified file containing the current time and the number
of actions that have been sent to the robot.

The purpose of this log is get an idea of how long the mechanics of the
robot last before things break.  The parameter expects a list of log
files so that separate logs for the separate manipulators of TriFinger
can be maintained.

The accompanying plot script can be used to view the logs.  It produces
a plot of the accumulated run duration over time:

![Figure_1](https://user-images.githubusercontent.com/9333121/112963416-a3199380-9147-11eb-89eb-411cb521bc40.png)


## How I Tested

On the single FingerOne robot.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
