### PR TITLE
Separate scripts for data and robot backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,8 @@ install_scripts(
     scripts/run_onejoint_tests.py
     scripts/single_finger_test.py
     scripts/trifinger_backend.py
+    scripts/trifinger_data_backend.py
+    scripts/trifinger_robot_backend.py
     scripts/trifingerpro_offset_calibration.py
     scripts/trifingerpro_post_submission.py
     scripts/trifingerpro_print_push_sensor.py

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hxx
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hxx
@@ -473,11 +473,11 @@ void NJBRD::shutdown()
     }
 
     // write number of actions to the run duration logs
-    std::cout << "Write run duration logs." << std::endl;
     int timestamp =
         static_cast<int>(real_time_tools::Timer::get_current_time_sec());
     for (const std::string &logfile_name : config_.run_duration_logfiles)
     {
+        std::cout << "Write run duration log " << logfile_name << std::endl;
         std::ofstream file(logfile_name, std::ios_base::app);
         if (!file)
         {

--- a/python/robot_fingers/ros/__init__.py
+++ b/python/robot_fingers/ros/__init__.py
@@ -1,0 +1,27 @@
+"""ROS-related classes/functions."""
+import rclpy
+import rclpy.node
+from std_msgs.msg import String
+from std_srvs.srv import Empty
+
+
+class NotificationNode(rclpy.node.Node):
+    """Simple ROS node for communication with other processes."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self._status_publisher = self.create_publisher(String, "~/status", 1)
+
+        self.shutdown_requested = False
+        self._shutdown_srv = self.create_service(
+            Empty, "~/shutdown", self.shutdown_callback
+        )
+
+    def shutdown_callback(self, request, response):
+        self.shutdown_requested = True
+        return response
+
+    def publish_status(self, status: str):
+        msg = String()
+        msg.data = status
+        self._status_publisher.publish(msg)

--- a/python/robot_fingers/ros/__init__.py
+++ b/python/robot_fingers/ros/__init__.py
@@ -1,6 +1,7 @@
 """ROS-related classes/functions."""
 import rclpy
 import rclpy.node
+import rclpy.qos
 from std_msgs.msg import String
 from std_srvs.srv import Empty
 
@@ -10,7 +11,19 @@ class NotificationNode(rclpy.node.Node):
 
     def __init__(self, name):
         super().__init__(name)
-        self._status_publisher = self.create_publisher(String, "~/status", 1)
+
+        # quality of service profile keep the last published message for late
+        # subscribers (like "latched" in ROS 1).
+        qos_profile = rclpy.qos.QoSProfile(
+            depth=1,
+            durability=rclpy.qos.DurabilityPolicy.TRANSIENT_LOCAL,
+            history=rclpy.qos.HistoryPolicy.KEEP_LAST,
+            reliability=rclpy.qos.ReliabilityPolicy.RELIABLE,
+        )
+
+        self._status_publisher = self.create_publisher(
+            String, "~/status", qos_profile
+        )
 
         self.shutdown_requested = False
         self._shutdown_srv = self.create_service(

--- a/python/robot_fingers/ros/__init__.py
+++ b/python/robot_fingers/ros/__init__.py
@@ -9,6 +9,9 @@ from std_srvs.srv import Empty
 class NotificationNode(rclpy.node.Node):
     """Simple ROS node for communication with other processes."""
 
+    _status_topic_name = "~/status"
+    _shutdown_service_name = "~/shutdown"
+
     def __init__(self, name):
         super().__init__(name)
 
@@ -22,12 +25,12 @@ class NotificationNode(rclpy.node.Node):
         )
 
         self._status_publisher = self.create_publisher(
-            String, "~/status", qos_profile
+            String, self._status_topic_name, qos_profile
         )
 
         self.shutdown_requested = False
         self._shutdown_srv = self.create_service(
-            Empty, "~/shutdown", self.shutdown_callback
+            Empty, self._shutdown_service_name, self.shutdown_callback
         )
 
     def shutdown_callback(self, request, response):

--- a/scripts/trifinger_data_backend.py
+++ b/scripts/trifinger_data_backend.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Run TriFinger Data Backend
+
+Runs the leader multi-processing robot/sensor data and loggers.
+"""
+import argparse
+import sys
+
+# ROS imports
+import rclpy
+
+import robot_interfaces
+from robot_fingers.ros import NotificationNode
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-number-of-actions",
+        "-a",
+        type=int,
+        required=True,
+        help="""Maximum numbers of actions that are processed.  After this the
+            backend shuts down automatically.
+        """,
+    )
+    camera_group = parser.add_mutually_exclusive_group()
+    camera_group.add_argument(
+        "--cameras",
+        "-c",
+        action="store_true",
+        help="Run camera backend.",
+    )
+    camera_group.add_argument(
+        "--cameras-with-tracker",
+        action="store_true",
+        help="Run camera backend with integrated object tracker.",
+    )
+    parser.add_argument(
+        "--robot-logfile",
+        type=str,
+        help="""Path to a file to which the robot data log is written.  If not
+            specified, no log is generated.
+        """,
+    )
+    parser.add_argument(
+        "--camera-logfile",
+        type=str,
+        help="""Path to a file to which the camera data is written.  If not
+            specified, no log is generated.
+        """,
+    )
+    args = parser.parse_args()
+
+    rclpy.init()
+    node = NotificationNode("trifinger_data")
+
+    logger = node.get_logger()
+
+    cameras_enabled = False
+    if args.cameras:
+        cameras_enabled = True
+        from trifinger_cameras import tricamera
+    elif args.cameras_with_tracker:
+        cameras_enabled = True
+        import trifinger_object_tracking.py_tricamera_types as tricamera
+
+    if cameras_enabled:
+        logger.info("Start camera data")
+
+        # make sure camera time series covers at least one second
+        CAMERA_TIME_SERIES_LENGTH = 15
+
+        camera_data = tricamera.MultiProcessData(
+            "tricamera", True, CAMERA_TIME_SERIES_LENGTH
+        )
+
+    logger.info("Start robot data")
+
+    # Storage for all observations, actions, etc.
+    history_size = args.max_number_of_actions + 1
+    robot_data = robot_interfaces.trifinger.MultiProcessData(
+        "trifinger", True, history_size=history_size
+    )
+
+    if args.robot_logfile:
+        robot_logger = robot_interfaces.trifinger.Logger(robot_data)
+
+    if cameras_enabled and args.camera_logfile:
+        camera_fps = 10
+        robot_rate_hz = 1000
+        # make the logger buffer a bit bigger as needed to be on the safe side
+        buffer_length_factor = 1.5
+
+        episode_length_s = args.max_number_of_actions / robot_rate_hz
+        # Compute camera log size based on number of robot actions plus some
+        # buffer
+        log_size = int(camera_fps * episode_length_s * buffer_length_factor)
+
+        logger.info("Initialize camera logger with buffer size %d" % log_size)
+        camera_logger = tricamera.Logger(camera_data, log_size)
+
+    logger.info("Data backend is ready")
+
+    # send ready signal
+    node.publish_status("READY")
+
+    if cameras_enabled and args.camera_logfile:
+        # wait for first action to be sent by the user
+        robot_data.desired_action.wait_for_timeindex(0)
+
+        camera_logger.start()
+        logger.info("Start camera logging")
+
+    while not node.shutdown_requested:
+        rclpy.spin_once(node)
+
+    logger.debug("Received shutdown signal")
+
+    if cameras_enabled and args.camera_logfile:
+        logger.info(
+            "Save recorded camera data to file %s" % args.camera_logfile
+        )
+        camera_logger.stop_and_save(args.camera_logfile)
+
+    if args.robot_logfile:
+        logger.info("Save robot data to file %s" % args.robot_logfile)
+        if args.max_number_of_actions:
+            end_index = args.max_number_of_actions
+        else:
+            end_index = -1
+
+        robot_logger.write_current_buffer_binary(
+            args.robot_logfile, start_index=0, end_index=end_index
+        )
+
+    rclpy.shutdown()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/trifinger_robot_backend.py
+++ b/scripts/trifinger_robot_backend.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Run TriFinger Robot back-end using follower multi-process robot data.
+
+This requires a leader robot data to be running in a separate process!
+"""
+import argparse
+import math
+import sys
+
+# ROS imports
+import rclpy
+
+import robot_interfaces
+import robot_fingers
+
+from robot_fingers.ros import NotificationNode
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--max-number-of-actions",
+        "-a",
+        type=int,
+        required=True,
+        help="""Maximum numbers of actions that are processed.  After this the
+            backend shuts down automatically.
+        """,
+    )
+    parser.add_argument(
+        "--first-action-timeout",
+        "-t",
+        type=float,
+        default=math.inf,
+        help="""Timeout (in seconds) for reception of first action after
+            starting the backend.  If not set, the timeout is disabled.
+        """,
+    )
+    camera_group = parser.add_mutually_exclusive_group()
+    camera_group.add_argument(
+        "--cameras",
+        "-c",
+        action="store_true",
+        help="Run camera backend.",
+    )
+    camera_group.add_argument(
+        "--cameras-with-tracker",
+        action="store_true",
+        help="Run camera backend with integrated object tracker.",
+    )
+    args = parser.parse_args()
+
+    rclpy.init()
+    node = NotificationNode("trifinger_backend")
+
+    logger = node.get_logger()
+
+    cameras_enabled = False
+    if args.cameras:
+        cameras_enabled = True
+        from trifinger_cameras import tricamera
+
+        CameraDriver = tricamera.TriCameraDriver
+    elif args.cameras_with_tracker:
+        cameras_enabled = True
+        import trifinger_object_tracking.py_tricamera_types as tricamera
+
+        CameraDriver = tricamera.TriCameraObjectTrackerDriver
+
+    if cameras_enabled:
+        logger.info("Start camera backend")
+
+        camera_data = tricamera.MultiProcessData("tricamera", False)
+        camera_driver = CameraDriver("camera60", "camera180", "camera300")
+        camera_backend = tricamera.Backend(camera_driver, camera_data)  # noqa
+
+        logger.info("Camera backend ready.")
+
+    logger.info("Start robot backend")
+
+    # Use robot-dependent config file
+    config_file_path = "/etc/trifingerpro/trifingerpro.yml"
+
+    # Storage for all observations, actions, etc.
+    robot_data = robot_interfaces.trifinger.MultiProcessData(
+        "trifinger", False
+    )
+
+    # The backend sends actions from the data to the robot and writes
+    # observations from the robot to the data.
+    backend = robot_fingers.create_trifinger_backend(
+        robot_data,
+        config_file_path,
+        first_action_timeout=args.first_action_timeout,
+        max_number_of_actions=args.max_number_of_actions,
+    )
+
+    # Initializes the robot (e.g. performs homing).
+    backend.initialize()
+
+    logger.info("Robot backend is ready")
+
+    # send ready signal
+    node.publish_status("READY")
+
+    # wait until backend terminates or shutdown request is received
+    while backend.is_running():
+        if node.shutdown_requested:
+            backend.request_shutdown()
+            backend.wait_until_terminated()
+            break
+
+    termination_reason = backend.get_termination_reason()
+    logger.debug("Backend termination reason: %d" % termination_reason)
+
+    rclpy.shutdown()
+    if termination_reason < 0:
+        # negate code as exit codes should be positive
+        return -termination_reason
+    else:
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

The "data backend" only runs the multi-process robot/sensor data and
loggers and the actual robot/sensor backends are run in the "robot
backend" script.  This way there is better control when shutting down
things as the robot data can still stay alive for the loggers and user
code to finish when the robot backend has already shut down.

Use ROS publishers to notify when the backends are ready and services to
shut them down cleanly.


## How I Tested

Tested with the submission system.


## Do not merge before

- [x] https://github.com/machines-in-motion/time_series/pull/22

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
