### PR TITLE
Do not ignore shutdown requests in trifinger robot and data back end

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.black]
+line-length = 79
+
+[tool.pylint.messages_control]
+disable = "C0330, C0326"

--- a/python/robot_fingers/ros/__init__.py
+++ b/python/robot_fingers/ros/__init__.py
@@ -34,6 +34,9 @@ class NotificationNode(rclpy.node.Node):
         )
 
     def shutdown_callback(self, request, response):
+        self.get_logger().info(
+            "Node {} received shutdown request.".format(self.get_name())
+        )
         self.shutdown_requested = True
         return response
 

--- a/scripts/trifinger_data_backend.py
+++ b/scripts/trifinger_data_backend.py
@@ -111,8 +111,15 @@ def main():
     node.publish_status("READY")
 
     if cameras_enabled and args.camera_logfile:
-        # wait for first action to be sent by the user
-        robot_data.desired_action.wait_for_timeindex(0)
+        # wait for first action to be sent by the user (but make sure to not
+        # block when shutdown is requested)
+        while (
+            not robot_data.desired_action.wait_for_timeindex(
+                0, max_duration_s=1
+            )
+            and not node.shutdown_requested
+        ):
+            rclpy.spin_once(node, timeout_sec=0)
 
         camera_logger.start()
         logger.info("Start camera logging")

--- a/scripts/trifinger_robot_backend.py
+++ b/scripts/trifinger_robot_backend.py
@@ -105,6 +105,7 @@ def main():
 
     # wait until backend terminates or shutdown request is received
     while backend.is_running():
+        rclpy.spin_once(node, timeout_sec=1)
         if node.shutdown_requested:
             backend.request_shutdown()
             backend.wait_until_terminated()


### PR DESCRIPTION
## Description

Fix issues that the trifinger robot and data back end where not terminating when shutdown was requested before the first action was sent by the user.

Further add a pyproject.toml with Black configuration.

## How I Tested

Running it on the submission system with user code that terminates before sending any action.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
