### PR TITLE
GitHub Actions: No special arguments for Black

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,3 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - uses: psf/black@master
-        with:
-            black_args: "--check --diff --line-length=79"


### PR DESCRIPTION
## Description

After adding the pyproject.toml, it's not needed anymore to pass any explicit arguments to black, so remove that part from the config.


## How I Tested

Via this PR (verifying that the action passes with the changed config).