### PR TITLE
Add bindings for TriFingerPlatformFrontend::Action

### DIFF
--- a/srcpy/py_trifinger.cpp
+++ b/srcpy/py_trifinger.cpp
@@ -38,14 +38,18 @@ PYBIND11_MODULE(py_trifinger, m)
 
     // needed for bindings of camera observations
     pybind11::module::import("trifinger_object_tracking.py_tricamera_types");
+    auto trifinger_types =
+        pybind11::module::import("robot_interfaces.py_trifinger_types");
 
     bind_create_backend<TriFingerDriver>(m, "create_trifinger_backend");
     bind_driver_config<TriFingerDriver>(m, "TriFingerConfig");
 
     pybind11::class_<TriFingerPlatformFrontend,
-                     std::shared_ptr<TriFingerPlatformFrontend>>(
-        m, "TriFingerPlatformFrontend")
-        .def(pybind11::init<>())
+                     std::shared_ptr<TriFingerPlatformFrontend>>
+        PyTriFingerPlatformFrontend(m, "TriFingerPlatformFrontend");
+    // expose the "Action" typedef to Python
+    PyTriFingerPlatformFrontend.attr("Action") = trifinger_types.attr("Action");
+    PyTriFingerPlatformFrontend.def(pybind11::init<>())
         .def("append_desired_action",
              &TriFingerPlatformFrontend::append_desired_action,
              pybind11::call_guard<pybind11::gil_scoped_release>(),


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

This way it can be exchanged with
`trifinger_simulation.TriFingerPlatform` in situations where
`platform.Action` is used.


## How I Tested

Used it in some code that is supposed to work with both the real frontend and the simulation.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
