### PR TITLE
fix: Return milliseconds in TriFingerPlatformLog::get_timestamp_ms

### DIFF
--- a/scripts/trifinger_platform_log_analyzer.py
+++ b/scripts/trifinger_platform_log_analyzer.py
@@ -15,23 +15,25 @@ def main():
 
     log = robot_fingers.TriFingerPlatformLog(args.robot_log, args.camera_log)
 
-    robot_timestamps = []
-    camera_timestamps = []
+    robot_timestamps_ms = []
+    camera_timestamps_ms = []
 
     # iterate over all robot time steps in the log
     for t in range(log.get_first_timeindex(), log.get_last_timeindex() + 1):
-        robot_timestamps.append(log.get_timestamp_ms(t))
+        robot_timestamps_ms.append(log.get_timestamp_ms(t))
 
         # show images of camera180
         try:
             camera_observation = log.get_camera_observation(t)
-            camera_timestamps.append(camera_observation.cameras[0].timestamp)
+            camera_timestamps_ms.append(
+                camera_observation.cameras[0].timestamp * 1000.0
+            )
         except Exception as e:
             print(e)
-            camera_timestamps.append(0)
+            camera_timestamps_ms.append(0)
 
-    plt.plot(robot_timestamps, label="robot")
-    plt.plot(camera_timestamps, label="camera")
+    plt.plot(robot_timestamps_ms, label="robot")
+    plt.plot(camera_timestamps_ms, label="camera")
     plt.legend()
     plt.show()
 

--- a/src/trifinger_platform_log.cpp
+++ b/src/trifinger_platform_log.cpp
@@ -74,7 +74,8 @@ TriFingerPlatformLog::RobotStatus TriFingerPlatformLog::get_robot_status(
 time_series::Timestamp TriFingerPlatformLog::get_timestamp_ms(
     const time_series::Index &t) const
 {
-    return robot_log_.data.at(t - robot_log_start_index_).timestamp;
+    // the timestamp in the log is in seconds
+    return robot_log_.data.at(t - robot_log_start_index_).timestamp * 1000.0;
 }
 
 TriFingerPlatformLog::CameraObservation


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
The `get_timestamp_ms()` method was erroneously returning the timestamp
in seconds instead of milliseconds.

Also fix the script trifinger_platform_log_analyzer.py accordingly,
which is using these timestamps.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
