### PR TITLE
Add option --fail-on-incomplete-run to robot backend

### DIFF
--- a/scripts/trifinger_robot_backend.py
+++ b/scripts/trifinger_robot_backend.py
@@ -72,7 +72,7 @@ def main():
 
         camera_data = tricamera.MultiProcessData("tricamera", False)
         camera_driver = CameraDriver("camera60", "camera180", "camera300")
-        camera_backend = tricamera.Backend(camera_driver, camera_data)  # noqa
+        camera_backend = tricamera.Backend(camera_driver, camera_data)
 
         logger.info("Camera backend ready.")
 
@@ -110,6 +110,9 @@ def main():
             backend.request_shutdown()
             backend.wait_until_terminated()
             break
+
+    if cameras_enabled:
+        camera_backend.shutdown()
 
     termination_reason = backend.get_termination_reason()
     logger.debug("Backend termination reason: %d" % termination_reason)


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

If this flag is set, all termination reasons different to MAXIMUM_NUMBER_OF_ACTIONS_REACHED is considered a failure as it is assumed that the run was not complete in this case.


## How I Tested

On the submission system.  With the flag set, runs that terminate early (and thus cause the backend to be shut down before the action limit is reached) result in a backend error.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/109

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
