### PR TITLE
Add FingerPro Endurance Test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ install_scripts(
     scripts/demonstrate_trajectory.py
     scripts/evaluate_log.py
     scripts/fingeredu_endurance_test.py
+    scripts/fingerpro_endurance_test.py
     scripts/joint_friction_calibration.py
     scripts/plot_logged_data.py
     scripts/plot_run_duration_log.py

--- a/config/fingerpro.yml
+++ b/config/fingerpro.yml
@@ -1,0 +1,51 @@
+can_ports: ["can0", "can1"]
+max_current_A: 2.2
+has_endstop: true
+
+homing_method: endstop_release
+home_offset_rad: [-2.136, -2.442, +2.710]
+
+move_to_position_tolerance_rad: 0.1
+calibration:
+    endstop_search_torques_Nm:
+        - +0.3
+        - +0.3
+        - -0.2
+    move_steps: 500
+safety_kd:
+    - 0.09
+    - 0.09
+    - 0.05
+position_control_gains:
+    kp: [9, 9, 9]
+    kd: [0.01, 0.01, 0.01]
+
+
+#hard_position_limits_lower: [-.inf, -.inf, -.inf]
+#hard_position_limits_upper: [.inf, .inf, .inf]
+
+hard_position_limits_lower:
+    - -1.0
+    - -1.67
+    - -2.8
+hard_position_limits_upper:
+    - 1.5
+    - 1.67
+    - 2.8
+
+# Set limits such that the motors cannot collide with the middle links
+soft_position_limits_lower:
+    - -0.33
+    - 0.0
+    - -2.7
+soft_position_limits_upper:
+    - 1.0
+    - 1.57
+    - 0.0
+
+# Set the initial position such that it is still save when the stage is at the
+# highest level.
+initial_position_rad:
+    - 0
+    - 0.9
+    - -1.7

--- a/python/robot_fingers/robot.py
+++ b/python/robot_fingers/robot.py
@@ -34,6 +34,11 @@ robot_configs = {
         robot_fingers.create_trifinger_backend,
         "trifingeredu.yml",
     ),
+    "fingerpro": (
+        robot_interfaces.finger,
+        robot_fingers.create_real_finger_backend,
+        "fingerpro.yml",
+    ),
     "trifingerpro": (
         robot_interfaces.trifinger,
         robot_fingers.create_trifinger_backend,

--- a/python/robot_fingers/robot.py
+++ b/python/robot_fingers/robot.py
@@ -1,5 +1,7 @@
 """Classes and functions to easily set up robot demo scripts."""
 import os
+
+import yaml
 from ament_index_python.packages import get_package_share_directory
 
 import robot_interfaces
@@ -121,6 +123,10 @@ class Robot:
                 "config",
                 config_file_name,
             )
+        # load the config and store parameters here, so they can easily be
+        # accessed at runtime
+        with open(config_file_path, "r") as f:
+            self.config = yaml.safe_load(f)
 
         # Storage for all observations, actions, etc.
         self.robot_data = robot_module.SingleProcessData()

--- a/scripts/fingerpro_endurance_test.py
+++ b/scripts/fingerpro_endurance_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Endurance test for single FingerPro.
+
+Moves the finger around to random positions.  The joint ranges are limited a
+bit to avoid self-collisions with the base.  Apart from this it is assumed that
+the finger can move freely within its valid range without collisions.
+"""
+import numpy as np
+
+import robot_interfaces
+import robot_fingers
+
+
+def get_random_position():
+    """Generate a random position within a save range."""
+    position_min = np.array([-0.6, -1.5, -2])
+    position_max = np.array([1, 0.6, 2])
+
+    position_range = position_max - position_min
+
+    return position_min + np.random.rand(3) * position_range
+
+
+def main():
+    robot = robot_fingers.Robot.create_by_name("fingerpro")
+    robot.initialize()
+
+    # first move to zero position, so it is easy to detect if there is some
+    # initialisation issue
+    action = robot_interfaces.finger.Action(position=[0, 0, 0])
+    for _ in range(300):
+        t = robot.frontend.append_desired_action(action)
+        robot.frontend.wait_until_timeindex(t)
+    input(
+        "Verify that finger is pointing straight down."
+        "  Press Enter to continue or Ctrl+C to abort."
+    )
+
+    limit_low = robot.config["soft_position_limits_lower"]
+    limit_up = robot.config["soft_position_limits_upper"]
+
+    time_printer = robot_fingers.utils.TimePrinter()
+
+    while True:
+        # get random position within the robot's valid range
+        position = np.random.uniform(limit_low, limit_up)
+
+        # reject configurations that might collide with the robot's base
+        if position[1] > 1.2 and position[2] > -1.1:
+            continue
+
+        for _ in range(300):
+            action = robot_interfaces.finger.Action(position=position)
+            t = robot.frontend.append_desired_action(action)
+            robot.frontend.wait_until_timeindex(t)
+
+        # print current date/time every hour, so we can roughly see how long it
+        # ran in case it crashes during a long-run-test.
+        time_printer.update()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Description

Add endurance test script for a single FingerPro.  The script uses the whole position range as specified in the config with just some small restrictions to avoid collisions with the base link.

For this the `Robot` class is extended to load and provide access to the robot configuration (used to get the position range).


## How I Tested

By running it on the test stand.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
