### PR TITLE
PlatformLog: Allow access to underlying logs

### DIFF
--- a/include/robot_fingers/trifinger_platform_log.hpp
+++ b/include/robot_fingers/trifinger_platform_log.hpp
@@ -76,6 +76,35 @@ public:
     }
 
     /**
+     * @brief Access the robot log.
+     */
+    const robot_interfaces::TriFingerTypes::BinaryLogReader &get_robot_log()
+        const
+    {
+        return robot_log_;
+    }
+
+    /**
+     * @brief Access the camera log.
+     */
+    const robot_interfaces::SensorLogReader<CameraObservation> &get_camera_log()
+        const
+    {
+        return camera_log_;
+    }
+
+    /**
+     * @brief Access the index mapping from robot to camera log.
+     *
+     * Note that the robot observation index does not necessarily match with the
+     * time index!
+     */
+    const std::vector<int> &get_map_robot_to_camera_index() const
+    {
+        return map_robot_to_camera_index_;
+    }
+
+    /**
      * @brief Get robot observation of the time step t.
      */
     RobotObservation get_robot_observation(const time_series::Index &t) const

--- a/srcpy/py_trifinger.cpp
+++ b/srcpy/py_trifinger.cpp
@@ -194,6 +194,15 @@ void pybind_trifinger_platform_log(pybind11::module &m, const std::string &name)
         .def(pybind11::init<const std::string &, const std::string &>(),
              "robot_log_file"_a,
              "camera_log_file"_a)
+        .def("get_robot_log",
+             &T::get_robot_log,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_camera_log",
+             &T::get_camera_log,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_map_robot_to_camera_index",
+             &T::get_map_robot_to_camera_index,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("get_robot_observation",
              &T::get_robot_observation,
              pybind11::call_guard<pybind11::gil_scoped_release>(),


### PR DESCRIPTION
## Description
Add getters to give (const) access to the underlying robot and camera
log as well as the mapping between the two.


## How I Tested

By using them in a script that converts the log to a different format.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
