### PR TITLE
Don't create temporary config file in trifingerpro_post_submission

### DIFF
--- a/scripts/fingerpro_endurance_test.py
+++ b/scripts/fingerpro_endurance_test.py
@@ -6,7 +6,6 @@ bit to avoid self-collisions with the base.  Apart from this it is assumed that
 the finger can move freely within its valid range without collisions.
 """
 import argparse
-import os
 
 import numpy as np
 
@@ -45,8 +44,8 @@ def move_with_random_positions():
     # initialisation issue
     initialize(robot.frontend)
 
-    limit_low = robot.config["soft_position_limits_lower"]
-    limit_up = robot.config["soft_position_limits_upper"]
+    limit_low = robot.config.soft_position_limits_lower
+    limit_up = robot.config.soft_position_limits_upper
 
     time_printer = robot_fingers.utils.TimePrinter()
 


### PR DESCRIPTION
## Description

Do not create a temporary configuration file in trifingerpro_post_submission.py to remove the position limits but instead use a config object. This resolves the permission issue when different users run the script on the same machine and is generally nicer.

Modify the `Robot` class for this, so that it can handle both config objects and file paths.


## How I Tested

By running it on one of the robots.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
