### PR TITLE
Fix demonstrate_trajectory and add dice reset trajectory

### DIFF
--- a/python/robot_fingers/robot.py
+++ b/python/robot_fingers/robot.py
@@ -87,17 +87,20 @@ def get_config_dir() -> pathlib.PurePath:
 
 class Robot:
     @classmethod
-    def create_by_name(cls, robot_name):
+    def create_by_name(cls, robot_name: str, logger_buffer_size: int = 0):
         """Create a ``Robot`` instance for the specified robot.
 
         Args:
-            robot_name (str):  Name of the robots.  See
+            robot_name:  Name of the robots.  See
             :meth:`Robot.get_supported_robots` for a list of supported robots.
+            logger_buffer_size:  See :meth:`Robot.__init__`.
 
         Returns:
             Robot: A ``Robot`` instance for the specified robot.
         """
-        return cls(*robot_configs[robot_name])
+        return cls(
+            *robot_configs[robot_name], logger_buffer_size=logger_buffer_size
+        )
 
     @staticmethod
     def get_supported_robots():
@@ -108,7 +111,13 @@ class Robot:
         """
         return robot_configs.keys()
 
-    def __init__(self, robot_module, create_backend_function, config):
+    def __init__(
+        self,
+        robot_module,
+        create_backend_function,
+        config,
+        logger_buffer_size=0,
+    ):
         """Initialize the robot environment (backend and frontend).
 
         :param robot_module: The module that defines the robot classes (i.e.
@@ -117,6 +126,9 @@ class Robot:
         :param config: Either a config object or a path to a config file.
             In the latter case, paths need to be absolute or relative to the
             config directory of the robot_fingers package.
+        :param logger_buffer_size: Size of the buffer used by the logger.
+            Default is 0.  Set this to at least the expected number of time
+            steps when using the logger.
         """
         # convenience mapping of the Action type
         self.Action = robot_module.Action
@@ -157,7 +169,7 @@ class Robot:
         self.frontend = robot_module.Frontend(self.robot_data)
 
         #: The logger can be used to log robot data to a file
-        self.logger = robot_module.Logger(self.robot_data, 100)
+        self.logger = robot_module.Logger(self.robot_data, logger_buffer_size)
 
     def initialize(self):
         """Initialize the robot."""

--- a/scripts/demonstrate_trajectory.py
+++ b/scripts/demonstrate_trajectory.py
@@ -79,7 +79,9 @@ def loop(win, args):
     title = "Demonstration Recorder"
     status_line = " q: quit | space: start/stop recording"
 
-    robot = robot_fingers.Robot.create_by_name(args.robot_type)
+    robot = robot_fingers.Robot.create_by_name(
+        args.robot_type, logger_buffer_size=300000
+    )
     robot.initialize()
 
     gui = SimpleCursesGUI(win, title, status_line)
@@ -101,9 +103,11 @@ def loop(win, args):
                 return
             elif pressed_key == ord(" "):
                 if is_recording:
-                    robot.logger.stop()
+                    robot.logger.stop_and_save(
+                        args.outfile, robot.logger.Format.CSV
+                    )
                 else:
-                    robot.logger.start(args.outfile)
+                    robot.logger.start()
 
                 is_recording = not is_recording
 


### PR DESCRIPTION
## Description
- Allow setting of the logger buffer size in Robot
- fix: Adapt demonstrate_trajectory to changes in logger
- Add trajectory for shuffling the dice


## How I Tested

By running it multiple times.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
