### PR TITLE
Make trifingerpro_post_submission more flexible

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=79
+ignore=E203,W503

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -22,6 +22,7 @@ import tomli
 import robot_interfaces
 import robot_fingers
 import trifinger_object_tracking.py_tricamera_types as tricamera
+import trifinger_object_tracking.py_object_tracker
 
 
 # Distance from the zero position (finger pointing straight down) to the
@@ -236,11 +237,20 @@ def reset_object(robot, trajectory_file):
         robot.frontend.wait_until_timeindex(t)
 
 
-def check_if_cube_is_there():
+def check_if_cube_is_there(object_type: str):
     """Verify that the cube is still inside the arena."""
+
+    object_models = {
+        "cube": "cube_v2",
+        "cuboid": "cuboid_2x2x8_v2",
+    }
+
     camera_data = tricamera.SingleProcessData(history_size=5)
+    model = trifinger_object_tracking.py_object_tracker.get_model_by_name(
+        object_models[object_type]
+    )
     camera_driver = tricamera.TriCameraObjectTrackerDriver(
-        "camera60", "camera180", "camera300"
+        "camera60", "camera180", "camera300", model
     )
     camera_backend = tricamera.Backend(camera_driver, camera_data)
     camera_frontend = tricamera.Frontend(camera_data)
@@ -309,7 +319,7 @@ def main():
 
     if args.object in ["cube", "cuboid"]:
         print("Check if cube/cuboid is found")
-        check_if_cube_is_there()
+        check_if_cube_is_there(args.object)
 
 
 if __name__ == "__main__":

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -49,7 +49,9 @@ def load_object_type() -> typing.Optional[str]:
         return None
 
 
-def get_robot_config_without_position_limits() -> robot_fingers.TriFingerConfig:
+def get_robot_config_without_position_limits() -> (
+    robot_fingers.TriFingerConfig
+):
     """Get TriFingerPro configuration without position limits.
 
     Loads the TriFingerPro configuration from the default config file and
@@ -272,15 +274,16 @@ def main():
         type=str,
         metavar="OBJECT_TYPE",
         choices=["cube", "cuboid", "dice", "auto"],
-        help="""Specify with which object the robot is equipped (if any).  If set to
-            "auto", the object type is read from the submission system configuration.
+        help="""Specify with which object the robot is equipped (if any).  If
+            set to "auto", the object type is read from the submission system
+            configuration.
         """,
     )
     parser.add_argument(
         "--reset",
         action="store_true",
-        help="""Execute a trajectory to reset the object.  Only valid if --object is
-            set.
+        help="""Execute a trajectory to reset the object.  Only valid if
+            --object is set.
         """,
     )
     args = parser.parse_args()

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -258,18 +258,25 @@ def check_if_cube_is_there():
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
-        "--reset",
+        "--object",
         type=str,
         metavar="OBJECT_TYPE",
         choices=["cube", "cuboid", "dice", "auto"],
-        help="""Execute a trajectory to reset the object.  A different
-            trajectory is used depending on the specified object type.
+        help="""Specify with which object the robot is equipped (if any).  If set to
+            "auto", the object type is read from the submission system configuration.
+        """,
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help="""Execute a trajectory to reset the object.  Only valid if --object is
+            set.
         """,
     )
     args = parser.parse_args()
 
-    if args.reset == "auto":
-        args.reset = load_object_type()
+    if args.object == "auto":
+        args.object = load_object_type()
 
     config = get_robot_config_without_position_limits()
     robot = robot_fingers.Robot(
@@ -284,20 +291,23 @@ def main():
     print("Position reachability test")
     run_self_test(robot)
 
-    if args.reset == "cube":
-        print("Reset cube position")
-        reset_object(robot, "trifingerpro_shuffle_cube_trajectory_fast.csv")
-    elif args.reset == "cuboid":
-        print("Reset cuboid position")
-        reset_object(robot, "trifingerpro_recenter_cuboid_2x2x8.csv")
-    elif args.reset == "dice":
-        print("Shuffle dice positions")
-        reset_object(robot, "trifingerpro_shuffle_dice_trajectory.csv")
+    if args.reset:
+        if args.object == "cube":
+            print("Reset cube position")
+            reset_object(
+                robot, "trifingerpro_shuffle_cube_trajectory_fast.csv"
+            )
+        elif args.object == "cuboid":
+            print("Reset cuboid position")
+            reset_object(robot, "trifingerpro_recenter_cuboid_2x2x8.csv")
+        elif args.object == "dice":
+            print("Shuffle dice positions")
+            reset_object(robot, "trifingerpro_shuffle_dice_trajectory.csv")
 
     # terminate the robot
     del robot
 
-    if args.reset in ["cube", "cuboid"]:
+    if args.object in ["cube", "cuboid"]:
         print("Check if cube/cuboid is found")
         check_if_cube_is_there()
 

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -247,7 +247,6 @@ def main():
         type=str,
         metavar="OBJECT_TYPE",
         choices=["cube", "cuboid", "dice"],
-        default="cube",
         help="""Execute a trajectory to reset the object.  A different
             trajectory is used depending on the specified object type.
         """,
@@ -280,8 +279,9 @@ def main():
     # terminate the robot
     del robot
 
-    print("Check if cube is found")
-    check_if_cube_is_there()
+    if args.reset in ["cube", "cuboid"]:
+        print("Check if cube/cuboid is found")
+        check_if_cube_is_there()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

- separate argument for object type from `--reset`.  This allows checking if the object is still there without running the reset procedure.
- Only check for the object if object type is cube or cuboid.
- Remove default value, so the script can be run without specifying an object.  In this case no check or reset procedure are done (needed for setup without object).
- Allow setting object type to "auto", in which case it is loaded from /etc/trifingerpro/submission_system.toml.


## How I Tested

By running it on a robot.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
