### PR TITLE
chore: Add GitHub Workflow to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,14 @@
 
 name: Build and Test
 
-on: [pull_request]
+on:
+  pull_request:
+  # NOTE: By also running on master (=the default branch), we have a cache for
+  # the default branch which will be used by other branches if they don't have
+  # their own cache already (see scope of caches created by actions/cache).
+  push:
+    branches:
+     - master
 
 jobs:
   build_and_test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,24 @@ jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     steps:
+      # cache the .apptainer/ directory, so the image does not need to be
+      # downloaded every time
+      - name: Apptainer Cache
+        id: cache-apptainer
+        uses: actions/cache@v3
+        with:
+          path: ~/.apptainer/cache
+          key: ${{ runner.os }}-apptainer
+
       - name: Install Apptainer
         run: |
-          wget https://github.com/apptainer/apptainer/releases/download/v1.0.2/apptainer_1.0.2_amd64.deb
-          sudo apt-get install ./apptainer_1.0.2_amd64.deb
+          APPTAINER_VERSION=1.0.2
+          # download with -N into .apptainer/cache, so a cached version is used
+          # if possible
+          mkdir -p ~/.apptainer/cache  # make sure cache directory exists
+          cd ~/.apptainer/cache
+          wget -N https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/apptainer_${APPTAINER_VERSION}_amd64.deb
+          sudo apt-get install ./apptainer_${APPTAINER_VERSION}_amd64.deb
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+# Build the package and run tests, using the latest trifinger_user Apptainer
+# image.
+# The Apptainer image has a full ROBOT_FINGERS workspace installed, so all
+# dependencies are there and only the checked package needs to be build, not the
+# whole workspace.
+#
+# Note: The Apptainer image only gets automatically rebuild, if something in the
+# image definition changes, not when other packages are changed.  So to avoid
+# that the workspace in the container gets outdated, manual builds need to be
+# triggered regularly.
+
+name: Build and Test
+
+on: [pull_request]
+
+jobs:
+  build_and_test:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install Apptainer
+        run: |
+          wget https://github.com/apptainer/apptainer/releases/download/v1.0.2/apptainer_1.0.2_amd64.deb
+          sudo apt-get install ./apptainer_1.0.2_amd64.deb
+
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Add matcher for gcc warnings
+        run: |
+          echo "::add-matcher::.github/workflows/gcc_problem_matcher.json"
+
+      - name: Build
+        run: apptainer run oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/trifinger_user:latest colcon build
+
+      - name: Run tests
+        run: |
+          pkg_name=${GITHUB_REPOSITORY#*/}
+          echo "Run tests of package ${pkg_name}"
+          apptainer run oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/trifinger_user:latest colcon test --packages-select=${pkg_name}
+          apptainer run oras://ghcr.io/open-dynamic-robot-initiative/trifinger_singularity/trifinger_user:latest colcon test-result --verbose

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,18 +41,17 @@ jobs:
         id: cache-apptainer
         uses: actions/cache@v3
         with:
-          path: ~/.apptainer/cache
+          path: |
+            ~/.apptainer/cache
+            ~/apptainer_*_amd64.deb
           key: ${{ runner.os }}-apptainer-${{ steps.date.outputs.week }}
 
       - name: Install Apptainer
         run: |
           APPTAINER_VERSION=1.0.2
-          # download with -N into .apptainer/cache, so a cached version is used
-          # if possible
-          mkdir -p ~/.apptainer/cache  # make sure cache directory exists
-          cd ~/.apptainer/cache
-          wget -N https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/apptainer_${APPTAINER_VERSION}_amd64.deb
-          sudo apt-get install ./apptainer_${APPTAINER_VERSION}_amd64.deb
+          # download with -N, so a cached version is used if available
+          wget -P ~ -N https://github.com/apptainer/apptainer/releases/download/v${APPTAINER_VERSION}/apptainer_${APPTAINER_VERSION}_amd64.deb
+          sudo apt-get install ~/apptainer_${APPTAINER_VERSION}_amd64.deb
 
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,14 +24,24 @@ jobs:
   build_and_test:
     runs-on: ubuntu-20.04
     steps:
-      # cache the .apptainer/ directory, so the image does not need to be
-      # downloaded every time
+      # write the current week of the year to an output parameter so it can
+      # later be used in the cache key
+      - name: Get current week of the year
+        id: date
+        run: echo "::set-output name=week::$(date +'%W')"
+
+      # Cache the .apptainer/ directory, so the image does not need to be
+      # downloaded every time.
+      # The cache is created if it does not yet exists but changes in the cache
+      # are not stored in later runs.  As this makes the cache useless once
+      # the image changed, add the number of the current week to its key.  This
+      # way a new cache will be created once per week.
       - name: Apptainer Cache
         id: cache-apptainer
         uses: actions/cache@v3
         with:
           path: ~/.apptainer/cache
-          key: ${{ runner.os }}-apptainer
+          key: ${{ runner.os }}-apptainer-${{ steps.date.outputs.week }}
 
       - name: Install Apptainer
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,9 @@ name: Build and Test
 on:
   pull_request:
   # NOTE: By also running on master (=the default branch), we have a cache for
-  # the default branch which will be used by other branches if they don't have
-  # their own cache already (see scope of caches created by actions/cache).
+  # the default branch which can also be used by other branches (so we avoid
+  # that each branch creates its own cache).  See documentation of action/cache
+  # for more information.
   push:
     branches:
      - master

--- a/.github/workflows/gcc_problem_matcher.json
+++ b/.github/workflows/gcc_problem_matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "gcc",
+            "pattern": [
+                {
+                    "regexp": "^(.*):(\\d+):(\\d+):\\s+(?:fatal\\s+)?(warning|error):\\s+(.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Use the latest "trifinger_user" container (so all dependencies are there) to build the package and run tests.

Add a problem matcher to parse GCC errors/warnings.


## How I Tested

Will be tested through this PR.

I had a temporary commit introducing a build error.  The build failed as expected and the erroneous line was annotated:

![pr_github_workflow_build_gcc_error](https://user-images.githubusercontent.com/9333121/176910000-97913f66-2884-4844-bfe2-21817171c262.png)

Likewise gcc warnings are annotated in the diff (there are actually some warnings in this package, see at the bottom of the diff of this PR).

I further added another temporary commit, breaking one of the tests.  This was detected as well, see output of the corresponding build: https://github.com/open-dynamic-robot-initiative/robot_fingers/runs/7151338838?check_suite_focus=true