### PR TITLE
Suppress warning about designated initializers

### DIFF
--- a/include/robot_fingers/one_joint_driver.hpp
+++ b/include/robot_fingers/one_joint_driver.hpp
@@ -25,6 +25,12 @@ public:
     }
 
 private:
+
+// suppress warning about designated initializers (e.g. `.torque_constant_NmpA`)
+// only being available with C++20 (we will get there eventually so just ignore
+// the warning until then).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
     OneJointDriver(const MotorBoards &motor_boards, const Config &config)
         : SimpleNJointBlmcRobotDriver<1, 1>(motor_boards,
                                             create_motors(motor_boards),
@@ -36,6 +42,7 @@ private:
                                             config)
     {
     }
+#pragma GCC diagnostic pop
 
     static Motors create_motors(const MotorBoards &motor_boards)
     {

--- a/include/robot_fingers/real_finger_driver.hpp
+++ b/include/robot_fingers/real_finger_driver.hpp
@@ -22,6 +22,12 @@ public:
     }
 
 private:
+
+// suppress warning about designated initializers (e.g. `.torque_constant_NmpA`)
+// only being available with C++20 (we will get there eventually so just ignore
+// the warning until then).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
     RealFingerDriver(const MotorBoards &motor_boards, const Config &config)
         : NFingerDriver<1>(motor_boards,
                            create_motors(motor_boards),
@@ -33,6 +39,7 @@ private:
                            config)
     {
     }
+#pragma GCC diagnostic pop
 
     static Motors create_motors(const MotorBoards &motor_boards)
     {

--- a/include/robot_fingers/solo_eight_driver.hpp
+++ b/include/robot_fingers/solo_eight_driver.hpp
@@ -25,6 +25,12 @@ public:
     }
 
 private:
+
+// suppress warning about designated initializers (e.g. `.torque_constant_NmpA`)
+// only being available with C++20 (we will get there eventually so just ignore
+// the warning until then).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
    SoloEightDriver(const MotorBoards &motor_boards, const Config &config)
         : SimpleNJointBlmcRobotDriver<8, 4>(motor_boards,
                                             create_motors(motor_boards),
@@ -36,6 +42,7 @@ private:
                                             config)
     {
     }
+#pragma GCC diagnostic pop
 
     static Motors create_motors(const MotorBoards &motor_boards)
     {

--- a/include/robot_fingers/trifinger_driver.hpp
+++ b/include/robot_fingers/trifinger_driver.hpp
@@ -20,6 +20,12 @@ public:
     }
 
 private:
+
+// suppress warning about designated initializers (e.g. `.torque_constant_NmpA`)
+// only being available with C++20 (we will get there eventually so just ignore
+// the warning until then).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
     TriFingerDriver(const MotorBoards &motor_boards, const Config &config)
         : NFingerDriver<3>(motor_boards,
                            create_motors(motor_boards),
@@ -31,6 +37,7 @@ private:
                            config)
     {
     }
+#pragma GCC diagnostic pop
 
     static Motors create_motors(const MotorBoards &motor_boards)
     {

--- a/include/robot_fingers/two_joint_driver.hpp
+++ b/include/robot_fingers/two_joint_driver.hpp
@@ -25,6 +25,12 @@ public:
     }
 
 private:
+
+// suppress warning about designated initializers (e.g. `.torque_constant_NmpA`)
+// only being available with C++20 (we will get there eventually so just ignore
+// the warning until then).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
     TwoJointDriver(const MotorBoards &motor_boards, const Config &config)
         : SimpleNJointBlmcRobotDriver<2, 1>(motor_boards,
                                             create_motors(motor_boards),
@@ -36,6 +42,7 @@ private:
                                             config)
     {
     }
+#pragma GCC diagnostic pop
 
     static Motors create_motors(const MotorBoards &motor_boards)
     {


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Designated initializers for structs are only part of the C++ standard
from version 20.  They are already supported by GCC also for older
versions but it triggers a warning.
Since we will anyway eventually reach C++20, simply ignore the warning
until then (using pragmas).



## How I Tested

Compiled and verified that no warning is issued anymore.

