### PR TITLE
plot_post_submission_log: Plot multiple files separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- plot_post_submission_log.py now plots multiple log files side by side instead of
+  merging them.  This is useful for comparing different robots.
+  The option to merge multiple log files has been dropped but the merging can easily be
+  done beforehand, e.g. using `cat` and saving to a temporary file.
+
 ### Fixed
 - Update demo_data_logging to changed interface of the RobotLogger class.
 

--- a/scripts/plot_post_submission_log.py
+++ b/scripts/plot_post_submission_log.py
@@ -6,9 +6,9 @@ log file. This script reads that log to plot the results of the object
 detection test over time.
 """
 import argparse
+import json
 import pathlib
 import sys
-import json
 
 import numpy as np
 import matplotlib.pyplot as plt
@@ -43,27 +43,32 @@ def main():
     )
     args = parser.parse_args()
 
-    data = []
-    for filename in args.logfiles:
-        data.extend(read_file(filename))
-
-    position_displacement = [
-        np.linalg.norm(s["position"]["mean"][:2]) for s in data
-    ]
-    mean_confidence = [s["confidence"]["object_mean_confidence"] for s in data]
-    position_mean_error = [s["position"]["mean_error"] for s in data]
-    orientation_mean_error = [s["orientation"]["mean_error"] for s in data]
-
     fig, axes = plt.subplots(4, 1)
-    plot_data = (
-        ("Mean Confidence", mean_confidence),
-        ("Position Mean Error", position_mean_error),
-        ("Orientation Mean Error", orientation_mean_error),
-        ("Position Displacement from Center", position_displacement),
-    )
-    for ax, (title, data) in zip(axes, plot_data):
-        ax.set_title(title)
-        ax.plot(data)
+    labels = [x.name for x in args.logfiles]
+    for filename, label in zip(args.logfiles, labels):
+        data = read_file(filename)
+
+        position_displacement = [
+            np.linalg.norm(s["position"]["mean"][:2]) for s in data
+        ]
+        mean_confidence = [
+            s["confidence"]["object_mean_confidence"] for s in data
+        ]
+        position_mean_error = [s["position"]["mean_error"] for s in data]
+        orientation_mean_error = [s["orientation"]["mean_error"] for s in data]
+
+        plot_data = (
+            ("Mean Confidence", mean_confidence),
+            ("Position Mean Error", position_mean_error),
+            ("Orientation Mean Error", orientation_mean_error),
+            ("Position Displacement from Center", position_displacement),
+        )
+        for ax, (title, data) in zip(axes, plot_data):
+            ax.set_title(title)
+            ax.plot(data, label=label)
+
+    handles, labels = axes[0].get_legend_handles_labels()
+    fig.legend(handles, labels, loc="upper right")
 
     # to prevent overlap of subplots (must be called after creating the plots)
     fig.tight_layout()


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
plot_post_submission_log.py now plots multiple log files side by side instead of merging them.  This is useful for comparing different robots. The option to merge multiple log files has been dropped but the merging can easily be done beforehand, e.g. using `cat` and saving to a temporary file.


## How I Tested

By running it on both a single and on multiple files.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
