### PR TITLE
plot_post_submission_log: Show plot in terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### Added
 - Script `trifingerpro_replay_actions_from_log` to re-apply the actions from a robot log
   file.
+- `plot_post_submission_log`: When run remotely (i.e. no display available) use
+  [plotext](https://github.com/piccolomo/plotext) to show the plot directly in
+  the terminal or save as file to /tmp if plotext is not available.
 
 ### Changed
 - plot_post_submission_log.py now plots multiple log files side by side instead of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ module = [
     "matplotlib.*",
     "pandas",
     "pinocchio",
+    "plotext",
     "progressbar",
     "rclpy.*",
     "scipy.*",


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Automatically detect if a display is available and, if not, use plotext to show the plot directly in the terminal instead of using the matplotlib GUI.
This way, the logs can be viewed directly on the robot via SSH.

If plotext is not available, fall back to saving the plot as image to /tmp instead (i.e. plotext is an optional dependency).


## How I Tested

Ran it on the robot and locally.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
