### PR TITLE
fix: Correctly use base constructor (and simplify code)

### DIFF
--- a/include/robot_fingers/n_finger_driver.hpp
+++ b/include/robot_fingers/n_finger_driver.hpp
@@ -11,6 +11,14 @@
 
 namespace robot_fingers
 {
+// alias for the base class, so all template arguments only need to be listed
+// once
+template <size_t N_FINGERS>
+using _NFingerDriverBase =
+    NJointBlmcRobotDriver<robot_interfaces::NFingerObservation<N_FINGERS>,
+                          N_FINGERS * robot_interfaces::JOINTS_PER_FINGER,
+                          N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>;
+
 /**
  * @brief Driver for the Finger robots.
  *
@@ -20,21 +28,14 @@ namespace robot_fingers
  * @tparam N_FINGERS  Number of fingers on the robot.
  */
 template <size_t N_FINGERS>
-class NFingerDriver : public NJointBlmcRobotDriver<
-                          robot_interfaces::NFingerObservation<N_FINGERS>,
-                          N_FINGERS * robot_interfaces::JOINTS_PER_FINGER,
-                          N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>
+class NFingerDriver : public _NFingerDriverBase<N_FINGERS>
 {
 public:
-    typedef NJointBlmcRobotDriver<
-        robot_interfaces::NFingerObservation<N_FINGERS>,
-        N_FINGERS * robot_interfaces::JOINTS_PER_FINGER,
-        N_FINGERS * robot_interfaces::BOARDS_PER_FINGER>
-        Base;
     typedef robot_interfaces::NFingerObservation<N_FINGERS> Observation;
-    using typename Base::Vector;
+    using typename _NFingerDriverBase<N_FINGERS>::Vector;
 
-    using Base::NJointBlmcRobotDriver;
+    // inherit the base constructor
+    using _NFingerDriverBase<N_FINGERS>::_NFingerDriverBase;
 
     Observation get_latest_observation() override
     {


### PR DESCRIPTION
## Description

- Fix the `using` statement for using the base constructor.  The old version was not valid (it was compiling with gcc but not with clang).
- Use an alias template for the base class, so the whole list of template arguments only needs to be specified once.


## How I Tested
Build and ran tests.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
