### PR TITLE
doc: Use custom mainpage and toctree

### DIFF
--- a/doc/breathing_cat.toml
+++ b/doc/breathing_cat.toml
@@ -1,2 +1,6 @@
 [intersphinx.mapping]
 robot_interfaces = "https://open-dynamic-robot-initiative.github.io/robot_interfaces"
+
+[mainpage]
+title = "robot_fingers: (Tri-)Finger Robot Driver and Tools"
+auto_general_docs = false

--- a/doc_mainpage.rst
+++ b/doc_mainpage.rst
@@ -1,10 +1,9 @@
-robot_fingers: (Tri-)Finger Robot Driver and Tools
---------------------------------------------------
-
-Drivers, examples and basic scripts for the (Tri)Finger robots.
-
 .. image:: doc/images/trifingerpro_with_cube.jpg
    :align: center
+
+The ``robot_fingers`` package provides drivers, examples and basic scripts for
+using the (Tri)Finger robots with our :doc:`robot_interfaces
+<robot_interfaces:index>` package.
 
 The source code is hosted on GitHub_.  Please also use the `Bug Tracker`_ there
 if you have a question or want to report a bug.
@@ -12,24 +11,15 @@ if you have a question or want to report a bug.
 For more information, on the TriFinger robot and the general architecture of the
 software, see also our paper_ on the open-source version of the TriFinger robot.
 
-This package implements a ``RobotDriver`` for the (Tri-)Finger robots based on
-our robot_interfaces_ package.
+.. toctree::
+   :caption: General Documentation
+   :maxdepth: 1
 
-
-Links
------
-
-- Documentation_
-- `Source Code`_
-- `Bug Tracker`_
-
-
-License
--------
-
-This package is published under the `BSD 3-Clause License <LICENSE>`_.
-
-Copyright (c) 2020 Max Planck Gesellschaft
+   doc/installation.rst
+   doc/singularity.rst
+   doc/getting_started.rst
+   doc/homing.rst
+   doc/hardware_testing.rst
 
 
 .. _GitHub: https://github.com/open-dynamic-robot-initiative/robot_fingers
@@ -38,3 +28,4 @@ Copyright (c) 2020 Max Planck Gesellschaft
 .. _paper: https://arxiv.org/abs/2008.03596
 .. _Documentation: https://open-dynamic-robot-initiative.github.io/robot_fingers
 .. _robot_interfaces: https://open-dynamic-robot-initiative.github.io/robot_interfaces
+


### PR DESCRIPTION
## Description

Provide a dedicated mainpage for the documentation (which is used instead of the README) and use a custom toctree (instead of the auto-generated one), so we can control the order in which the pages are listed.
