### PR TITLE
Check camera sharpness in post-submission checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `plot_post_submission_log`: When run remotely (i.e. no display available) use
   [plotext](https://github.com/piccolomo/plotext) to show the plot directly in
   the terminal or save as file to /tmp if plotext is not available.
+- Check camera sharpness in `trifinger_post_submission.py`.  This should alert us early,
+  if a lense comes loose.
 
 ### Changed
 - plot_post_submission_log.py now plots multiple log files side by side instead of

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -354,7 +354,7 @@ def check_camera_sharpness(
     observations: typing.Sequence[tricamera.TriCameraObjectObservation],
     log: logging.Logger,
 ) -> bool:
-    """Check if all cameras are reasonable well in focus.
+    """Check if all cameras are reasonably well in focus.
 
     Uses Canny edge detection to estimate how sharp the images are
     (more edges = sharper).  If the mean value of the edge image is below a


### PR DESCRIPTION
## Description

Check the sharpness of the camera images using Canny edge detection (more edges means sharper image).  If the amount of edges is too low, this can indicate that the camera got out of focus for some reason (e.g. lense got loose).

Refactored the code a bit, such that camera observations only need to be recorded once and can then be used by every check that needs them.

The Canny parameters and edge threshold are manually tuned.  They looked good during my tests on roboch5, but we have to see, how well they work in practise.  The threshold is rather high (so we get notified early, if a lens comes loose).  If there are too many false alerts, we can reduce it a bit.

## How I Tested

By running it on roboch5 where one lens is currently a bit loose.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
