### PR TITLE
fix: Install interface target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ install(DIRECTORY config
 
 install(
     TARGETS
+        ${PROJECT_NAME}
         trifinger_platform_frontend
         trifinger_platform_log
         demo_trifinger_platform


### PR DESCRIPTION
## Description

The "robot_fingers" interface target was created but not installed, so it couldn't be used by other packages.


## How I Tested

Link to `robot_fingers::robot_fingers` in an other package.
