### PR TITLE
find pybind11 before ament_cmake to fix error on Ubuntu 22.04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 - Logger initialisation in `trifinger_backend`.
 - `trifinger_backend`: Use proper timeseries history length if no limit for
   number of actions is specified.
+- pybind11 build error on Ubuntu 22.04
+
 
 ## [1.0.0] - 2022-06-28
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,13 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 string(APPEND CMAKE_CXX_FLAGS " -Wfatal-errors -Werror=return-type")
 
 
-find_package(ament_cmake REQUIRED)
+# pybind11 needs to be first, otherwise other packages which also search for
+# Python can cause an 'Unknown CMake command "python3_add_library"' error.
+# Probably related to how Python is found, see
+# https://github.com/pybind/pybind11/issues/3996
 find_package(pybind11 REQUIRED)
+
+find_package(ament_cmake REQUIRED)
 find_package(mpi_cmake_modules REQUIRED)
 find_package(yaml_utils REQUIRED)
 find_package(blmc_drivers REQUIRED)


### PR DESCRIPTION
## Description

See title.

## How I Tested

By building and running tests.