### PR TITLE
Disable position limits for shutdown trajectory and change TriFingerPro rest position

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,15 +4,15 @@ on: [pull_request]
 
 jobs:
   mypy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: Install
         run: |
-          python3 -m pip install mypy types-PyYAML numpy==1.20.3
+          python3 -m pip install mypy types-PyYAML numpy==1.23.3
       - name: Add matcher
         run: |
           echo "::add-matcher::.github/workflows/mypy-problem-matcher.json"
@@ -21,12 +21,12 @@ jobs:
           python3 -m mypy .
 
   flake8:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - name: Install
         run: |
           python3 -m pip install flake8
@@ -39,20 +39,20 @@ jobs:
 
   black:
     name: Python Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: "3.10"
       - uses: psf/black@stable
 
   clang-format:
     name: C++ Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
       - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/scripts/run-clang-format
       - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/resources/_clang-format
       - run: python ./run-clang-format -r .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   dropping down.
 - Improved `demo_trifinger_platform.py` to use sine position profile instead of
   random motions and add option to use with object tracking.
+- Disable position limit checks during shutdown trajectory.  This allows setting
+  the rest position of the TriFingerPro to a more suitable position which is
+  outside of the operation limits.
 
 ### Fixed
 - Update demo_data_logging to changed interface of the RobotLogger class.

--- a/config/trifingerpro.yml
+++ b/config/trifingerpro.yml
@@ -97,6 +97,7 @@ shutdown_trajectory:
     - target_position_rad: [0, 0.9, -1.7, 0, 0.9, -1.7, 0, 0.9, -1.7]
       move_steps: 3000
     # then move to rest position (a position from which it cannot get stuck
-    # during homing for the next run).
-    - target_position_rad: [0.0161, 0.8998, -0.9770, 0.0161, 0.8998, -0.9770, 0.0161, 0.8998, -0.9770]
+    # during homing for the next run and that is a good initial position for
+    # calibration on first run after power on).
+    - target_position_rad: [1.57, 1.8, -2.5, 1.57, 1.8, -2.5, 1.57, 1.8, -2.5]
       move_steps: 1000

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -180,6 +180,8 @@ public:
      * @param safety_kd  D-gain for velocity damping.
      * @param default_position_control_kp  Default P-gain for position control.
      * @param default_position_control_kd  Default D-gain for position control.
+     * @param is_position_limit_enabled  If false, position limit checks are
+     *      skipped.
      * @param lower_position_limits  Lower limits for joint positions.
      * @param upper_position_limits  Upper limits for joint positions.
      *
@@ -192,6 +194,7 @@ public:
         const Vector &safety_kd,
         const Vector &default_position_control_kp,
         const Vector &default_position_control_kd,
+        bool is_position_limit_enabled,
         const Vector &lower_position_limits =
             Vector::Constant(-std::numeric_limits<double>::infinity()),
         const Vector &upper_position_limits =
@@ -222,10 +225,13 @@ protected:
      */
     Config config_;
 
-    bool is_initialized_ = false;
+    bool is_initialized_ = true;
 
     //! \brief Counter for the number of actions sent to the robot.
     uint32_t action_counter_ = 0;
+
+    //! \brief Whether or not position limits (both soft and hard) are checked.
+    bool is_position_limit_enabled_ = false;
 
     Action apply_action_uninitialized(const Action &desired_action);
 
@@ -283,6 +289,17 @@ protected:
     bool move_to_position(const Vector &goal_pos,
                           const double tolerance,
                           const uint32_t time_steps);
+
+    //! Enable the position limits
+    void enable_position_limits()
+    {
+        is_position_limit_enabled_ = true;
+    }
+    //! Disable the position limits
+    void disable_position_limits()
+    {
+        is_position_limit_enabled_ = false;
+    }
 };
 
 /**

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hxx
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hxx
@@ -451,6 +451,9 @@ std::string NJBRD::get_error()
 TPL_NJBRD
 void NJBRD::shutdown()
 {
+    // The shutdown trajectory is allowed to violate the position limits
+    disable_position_limits();
+
     // Move on the shutdown trajectory step by step.  If no shutdown trajectory
     // is configured, the list of steps will be empty, so nothing will happen.
     bool success = true;
@@ -495,6 +498,10 @@ void NJBRD::shutdown()
             file << timestamp << "\t" << action_counter_ << std::endl;
         }
     }
+
+    // shouldn't be needed anymore after shutdown but nonetheless make sure
+    // position limits are only disabled locally
+    enable_position_limits();
 }
 
 TPL_NJBRD

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hxx
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hxx
@@ -343,7 +343,8 @@ void NJBRD::initialize()
 
     real_time_tools::RealTimeThread realtime_thread;
     realtime_thread.create_realtime_thread(
-        [](void *instance_pointer) {
+        [](void *instance_pointer)
+        {
             // instance_pointer = this, cast to correct type and call the
             // _initialize() method.
             ((NJBRD *)(instance_pointer))->_initialize();
@@ -503,6 +504,7 @@ auto NJBRD::process_desired_action(const Action &desired_action,
                                    const Vector &safety_kd,
                                    const Vector &default_position_control_kp,
                                    const Vector &default_position_control_kd,
+                                   bool is_position_limit_enabled,
                                    const Vector &lower_position_limits,
                                    const Vector &upper_position_limits)
     -> Action
@@ -513,46 +515,54 @@ auto NJBRD::process_desired_action(const Action &desired_action,
     // ---------------
     // If a joint exceeds the soft position limit, replace the command for that
     // joint with a position command to the limit
-    for (std::size_t i = 0; i < N_JOINTS; i++)
+    if (is_position_limit_enabled)
     {
-        // Clamp position commands to the allowed range (note that if position
-        // is NaN both conditions are false, so the NaN is preserved).
-        if (processed_action.position[i] < lower_position_limits[i])
+        for (std::size_t i = 0; i < N_JOINTS; i++)
         {
-            processed_action.position[i] = lower_position_limits[i];
-        }
-        else if (processed_action.position[i] > upper_position_limits[i])
-        {
-            processed_action.position[i] = upper_position_limits[i];
-        }
-
-        auto set_limit_action = [&](double sign, double limit) {
-            // Discard torque command if it pushes further out of the valid
-            // range.
-            if (processed_action.torque[i] * sign > 0)
+            // Clamp position commands to the allowed range (note that if
+            // position is NaN both conditions are false, so the NaN is
+            // preserved).
+            if (processed_action.position[i] < lower_position_limits[i])
             {
-                processed_action.torque[i] = 0;
+                processed_action.position[i] = lower_position_limits[i];
+            }
+            else if (processed_action.position[i] > upper_position_limits[i])
+            {
+                processed_action.position[i] = upper_position_limits[i];
             }
 
-            // If no position is set, set it to the limit value (otherwise it
-            // will already be clamped to the limit range, so it will be fine).
-            if (std::isnan(processed_action.position[i]))
+            auto set_limit_action = [&](double sign, double limit)
             {
-                processed_action.position[i] = limit;
+                // Discard torque command if it pushes further out of the valid
+                // range.
+                if (processed_action.torque[i] * sign > 0)
+                {
+                    processed_action.torque[i] = 0;
+                }
+
+                // If no position is set, set it to the limit value (otherwise
+                // it will already be clamped to the limit range, so it will be
+                // fine).
+                if (std::isnan(processed_action.position[i]))
+                {
+                    processed_action.position[i] = limit;
+                }
+
+                // do not allow custom gains
+                processed_action.position_kp[i] =
+                    default_position_control_kp[i];
+                processed_action.position_kd[i] =
+                    default_position_control_kd[i];
+            };
+
+            if (latest_observation.position[i] < lower_position_limits[i])
+            {
+                set_limit_action(-1, lower_position_limits[i]);
             }
-
-            // do not allow custom gains
-            processed_action.position_kp[i] = default_position_control_kp[i];
-            processed_action.position_kd[i] = default_position_control_kd[i];
-        };
-
-        if (latest_observation.position[i] < lower_position_limits[i])
-        {
-            set_limit_action(-1, lower_position_limits[i]);
-        }
-        else if (latest_observation.position[i] > upper_position_limits[i])
-        {
-            set_limit_action(+1, upper_position_limits[i]);
+            else if (latest_observation.position[i] > upper_position_limits[i])
+            {
+                set_limit_action(+1, upper_position_limits[i]);
+            }
         }
     }
 
@@ -609,7 +619,9 @@ auto NJBRD::process_desired_action(const Action &desired_action,
 TPL_NJBRD
 bool NJBRD::is_within_hard_position_limits(const Observation &observation) const
 {
-    return config_.is_within_hard_position_limits(observation.position);
+    // if position limits are disabled, always return true
+    return !is_position_limit_enabled_ ||
+           config_.is_within_hard_position_limits(observation.position);
 }
 
 TPL_NJBRD
@@ -619,18 +631,6 @@ auto NJBRD::apply_action_uninitialized(const NJBRD::Action &desired_action)
     double start_time_sec = real_time_tools::Timer::get_current_time_sec();
 
     Observation observation = get_latest_observation();
-
-    // Only enable soft position limits once initialization is done (i.e. no
-    // limits during homing).
-    Vector lower_limits =
-        is_initialized_
-            ? config_.soft_position_limits_lower
-            : Vector::Constant(-std::numeric_limits<double>::infinity());
-    Vector upper_limits =
-        is_initialized_
-            ? config_.soft_position_limits_upper
-            : Vector::Constant(std::numeric_limits<double>::infinity());
-
     Action applied_action =
         process_desired_action(desired_action,
                                observation,
@@ -638,8 +638,9 @@ auto NJBRD::apply_action_uninitialized(const NJBRD::Action &desired_action)
                                config_.safety_kd,
                                config_.position_control_gains.kp,
                                config_.position_control_gains.kd,
-                               lower_limits,
-                               upper_limits);
+                               is_position_limit_enabled_,
+                               config_.soft_position_limits_lower,
+                               config_.soft_position_limits_upper);
 
     joint_modules_.set_torques(applied_action.torque);
     joint_modules_.send_torques();
@@ -656,6 +657,10 @@ void NJBRD::_initialize()
 {
     joint_modules_.set_position_control_gains(
         config_.position_control_gains.kp, config_.position_control_gains.kd);
+
+    // During homing, the joints have to move to the end-stops, so disable
+    // position limits.
+    disable_position_limits();
 
     bool homing_succeeded = homing();
     pause_motors();
@@ -686,6 +691,8 @@ void NJBRD::_initialize()
     pause_motors();
 
     is_initialized_ = homing_succeeded;
+
+    enable_position_limits();
 }
 
 TPL_NJBRD


### PR DESCRIPTION
## Description

- Add methods to enable/disable position limit checks in the robot driver.
- Use the above to disable position limits during shutdown trajectory (it is now in the responsibility of the person writing the config file to make sure the trajectory is okay!)
- Change the TriFingerPro rest position to the "minimal gravitational pull on the joints"-position that is also used when powering on (so less need to manually move the joints).


## How I Tested
On a robot.

