### PR TITLE
Return std::optional in RobotDriver::get_error()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   broken light panels.
 
 ### Changed
+- Upgrade to robot_interfaces v2 (not yet released).
 - plot_post_submission_log.py now plots multiple log files side by side instead of
   merging them.  This is useful for comparing different robots.
   The option to merge multiple log files has been dropped but the merging can easily be

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ find_package(trifinger_object_tracking REQUIRED)
 ## System dependencies are found with CMake's conventions
 # find_package(Boost REQUIRED COMPONENTS system)
 find_package(Eigen3 REQUIRED)
+find_package(fmt REQUIRED)
 find_package(OpenCV REQUIRED)
 
 
@@ -47,6 +48,7 @@ target_include_directories(
 )
 target_link_libraries(${PROJECT_NAME} INTERFACE
     Eigen3::Eigen
+    fmt::fmt
     yaml_utils::yaml_utils
     blmc_drivers::blmc_drivers
     robot_interfaces::robot_interfaces

--- a/include/robot_fingers/fake_finger_driver.hpp
+++ b/include/robot_fingers/fake_finger_driver.hpp
@@ -59,9 +59,9 @@ public:
         return desired_action;
     }
 
-    std::string get_error() override
+    std::optional<std::string> get_error() override
     {
-        return "";  // no errors
+        return std::nullopt;  // no errors
     }
 
     void shutdown() override

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -12,9 +12,9 @@
 #include <iterator>
 #include <string>
 
+#include <fmt/format.h>
 #include <yaml-cpp/yaml.h>
 #include <Eigen/Eigen>
-#include <fmt/format.h>
 
 #include <robot_interfaces/monitored_robot_driver.hpp>
 #include <robot_interfaces/n_joint_robot_types.hpp>

--- a/include/robot_fingers/n_joint_blmc_robot_driver.hpp
+++ b/include/robot_fingers/n_joint_blmc_robot_driver.hpp
@@ -14,6 +14,7 @@
 
 #include <yaml-cpp/yaml.h>
 #include <Eigen/Eigen>
+#include <fmt/format.h>
 
 #include <robot_interfaces/monitored_robot_driver.hpp>
 #include <robot_interfaces/n_joint_robot_types.hpp>
@@ -139,7 +140,7 @@ public:
 
     virtual Observation get_latest_observation() override = 0;
     Action apply_action(const Action &desired_action) override;
-    std::string get_error() override;
+    std::optional<std::string> get_error() override;
     void shutdown() override;
 
     /**

--- a/include/robot_fingers/pybullet_driver.hpp
+++ b/include/robot_fingers/pybullet_driver.hpp
@@ -112,9 +112,9 @@ public:
         return applied_action;
     }
 
-    std::string get_error() override
+    std::optional<std::string> get_error() override
     {
-        return "";  // no errors
+        return std::nullopt;  // no errors
     }
 
     void shutdown() override


### PR DESCRIPTION
## Description

This is to keep up with a change in robot_interfaces (to be released in version 2.0).
Also refactor a bit.


## How I Tested

On a TriFinger robot (though only with position limit error, board errors are difficult to trigger manually...).
