### PR TITLE
Change Python line length to 88 (black default)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length=79
+max-line-length=88
 ignore=E203,W503

--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
      - master
+  workflow_dispatch:
 
 jobs:
   build_and_test:

--- a/demos/demo_data_logging.py
+++ b/demos/demo_data_logging.py
@@ -24,9 +24,7 @@ def main():
 
     # run the robot for a while
     for _ in range(10000):
-        t = finger_frontend.append_desired_action(
-            finger.Action(torque=desired_torque)
-        )
+        t = finger_frontend.append_desired_action(finger.Action(torque=desired_torque))
         finger_frontend.wait_until_timeindex(t)
 
     # stop logger and write data to file

--- a/demos/demo_simulation_driver.py
+++ b/demos/demo_simulation_driver.py
@@ -46,14 +46,10 @@ def main():
     num_fingers = finger_types_data.get_number_of_fingers(args.finger_type)
     if num_fingers == 1:
         finger_types = robot_interfaces.finger
-        create_backend = (
-            robot_fingers.pybullet_drivers.create_single_finger_backend
-        )
+        create_backend = robot_fingers.pybullet_drivers.create_single_finger_backend
     elif num_fingers == 3:
         finger_types = robot_interfaces.trifinger
-        create_backend = (
-            robot_fingers.pybullet_drivers.create_trifinger_backend
-        )
+        create_backend = robot_fingers.pybullet_drivers.create_trifinger_backend
 
     robot_data = finger_types.SingleProcessData()
 

--- a/demos/demo_simulation_object_tracker.py
+++ b/demos/demo_simulation_object_tracker.py
@@ -51,9 +51,7 @@ def main():
     cube = collision_objects.Block()
 
     # initialize the object tracker interface
-    object_tracker_data = object_tracker.Data(
-        "object_tracker", True, args.history_size
-    )
+    object_tracker_data = object_tracker.Data("object_tracker", True, args.history_size)
     object_tracker_backend = object_tracker.SimulationBackend(
         object_tracker_data, cube, real_time
     )

--- a/demos/demo_solo_eight.py
+++ b/demos/demo_solo_eight.py
@@ -49,9 +49,7 @@ def main():
     if args.multi_process:
         # In multi-process case assume that the backend is running in a
         # separate process and only set up the frontend here.
-        robot_data = robot_interfaces.solo_eight.MultiProcessData(
-            "solo8", False
-        )
+        robot_data = robot_interfaces.solo_eight.MultiProcessData("solo8", False)
         frontend = robot_interfaces.solo_eight.Frontend(robot_data)
     else:
         # In single-process case run both frontend and backend in this process

--- a/demos/demo_trifinger.py
+++ b/demos/demo_trifinger.py
@@ -80,9 +80,7 @@ def main():
     if args.multi_process:
         # In multi-process case assume that the backend is running in a
         # separate process and only set up the frontend here.
-        robot_data = robot_interfaces.trifinger.MultiProcessData(
-            "trifinger", False
-        )
+        robot_data = robot_interfaces.trifinger.MultiProcessData("trifinger", False)
         frontend = robot_interfaces.trifinger.Frontend(robot_data)
     else:
         # In single-process case run both frontend and backend in this process

--- a/demos/demo_trifinger_platform.py
+++ b/demos/demo_trifinger_platform.py
@@ -64,9 +64,7 @@ def main() -> None:  # noqa[D103]
 
         if t % 100 == 0:
             print(f"[{t}] target joint positions: {action.position}")
-            print(
-                f"[{t}] actual joint positions: {robot_observation.position}"
-            )
+            print(f"[{t}] actual joint positions: {robot_observation.position}")
 
             image = camera_observation.cameras[0].image
             print(f"[{t}] Image shape: {image.shape}")

--- a/demos/demo_trifingeredu.py
+++ b/demos/demo_trifingeredu.py
@@ -52,9 +52,7 @@ def main():
     if args.multi_process:
         # In multi-process case assume that the backend is running in a
         # separate process and only set up the frontend here.
-        robot_data = robot_interfaces.trifinger.MultiProcessData(
-            "trifinger", False
-        )
+        robot_data = robot_interfaces.trifinger.MultiProcessData("trifinger", False)
         frontend = robot_interfaces.trifinger.Frontend(robot_data)
     else:
         # In single-process case run both frontend and backend in this process

--- a/demos/demo_trifingerpro.py
+++ b/demos/demo_trifingerpro.py
@@ -56,9 +56,7 @@ def main():
     if args.multi_process:
         # In multi-process case assume that the backend is running in a
         # separate process and only set up the frontend here.
-        robot_data = robot_interfaces.trifinger.MultiProcessData(
-            "trifinger", False
-        )
+        robot_data = robot_interfaces.trifinger.MultiProcessData("trifinger", False)
         frontend = robot_interfaces.trifinger.Frontend(robot_data)
     else:
         # In single-process case run both frontend and backend in this process

--- a/demos/demo_trifingerpro_kinematics.py
+++ b/demos/demo_trifingerpro_kinematics.py
@@ -24,12 +24,8 @@ import robot_fingers
 
 def init_kinematics():
     """Initialise the kinematics calculator for TriFingerPro."""
-    robot_properties_path = get_package_share_directory(
-        "robot_properties_fingers"
-    )
-    urdf_file = trifinger_simulation.finger_types_data.get_finger_urdf(
-        "trifingerpro"
-    )
+    robot_properties_path = get_package_share_directory("robot_properties_fingers")
+    urdf_file = trifinger_simulation.finger_types_data.get_finger_urdf("trifingerpro")
     finger_urdf_path = os.path.join(robot_properties_path, "urdf", urdf_file)
     kinematics = trifinger_simulation.pinocchio_utils.Kinematics(
         finger_urdf_path,
@@ -53,9 +49,7 @@ def main():
         robot.initialize()
         frontend = robot.frontend
     else:
-        robot_data = robot_interfaces.trifinger.MultiProcessData(
-            "trifinger", False
-        )
+        robot_data = robot_interfaces.trifinger.MultiProcessData("trifinger", False)
         frontend = robot_interfaces.trifinger.Frontend(robot_data)
 
     kinematics = init_kinematics()
@@ -87,9 +81,7 @@ def main():
         # update desired tip positions
         for i in range(len(initial_cartesian_tip_positions)):
             dy = distance * np.sin(t * np.pi / n_steps)
-            cartesian_tip_positions[i][1] = (
-                initial_cartesian_tip_positions[i][1] + dy
-            )
+            cartesian_tip_positions[i][1] = initial_cartesian_tip_positions[i][1] + dy
 
         # use inverse kinematics to get the corresponding joint angles
         angular_joint_positions, err = kinematics.inverse_kinematics(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,3 @@
-[tool.black]
-line-length = 79
-
-[tool.ruff]
-line-length = 79
-
 [tool.pylint.messages_control]
 disable = "C0330, C0326"
 

--- a/robot_fingers/robot.py
+++ b/robot_fingers/robot.py
@@ -98,9 +98,7 @@ class Robot:
         Returns:
             Robot: A ``Robot`` instance for the specified robot.
         """
-        return cls(
-            *robot_configs[robot_name], logger_buffer_size=logger_buffer_size
-        )
+        return cls(*robot_configs[robot_name], logger_buffer_size=logger_buffer_size)
 
     @staticmethod
     def get_supported_robots():

--- a/robot_fingers/utils.py
+++ b/robot_fingers/utils.py
@@ -27,8 +27,6 @@ class TimePrinter:
             time_str = time.strftime("%F %H:%M")
             duration_h = round((now - self.start_time) / 3600)
             print(
-                "{} ({} h since {})".format(
-                    time_str, duration_h, self.start_time_str
-                )
+                "{} ({} h since {})".format(time_str, duration_h, self.start_time_str)
             )
             self._last_time_print = now

--- a/scripts/check_finger_position_control_error.py
+++ b/scripts/check_finger_position_control_error.py
@@ -61,8 +61,6 @@ if __name__ == "__main__":
             robot.frontend.wait_until_timeindex(t)
 
         desired_tip_pos = forward_kinematics(desired_position)
-        actual_tip_pos = forward_kinematics(
-            robot.frontend.get_observation(t).position
-        )
+        actual_tip_pos = forward_kinematics(robot.frontend.get_observation(t).position)
         error = desired_tip_pos - actual_tip_pos
         print("Position Error: {:.3}  {}".format(np.linalg.norm(error), error))

--- a/scripts/claw_crane.py
+++ b/scripts/claw_crane.py
@@ -17,16 +17,10 @@ from robot_fingers.curses import SimpleCursesGUI
 
 def loop(win, args):
     title = "Claw Crane"
-    status_line = (
-        " q: quit | a/d: x-axis | w/s: y-axis | r/f: z-axis | q/e: open/close"
-    )
+    status_line = " q: quit | a/d: x-axis | w/s: y-axis | r/f: z-axis | q/e: open/close"
 
-    robot_properties_path = get_package_share_directory(
-        "robot_properties_fingers"
-    )
-    urdf_file = trifinger_simulation.finger_types_data.get_finger_urdf(
-        "trifingerpro"
-    )
+    robot_properties_path = get_package_share_directory("robot_properties_fingers")
+    urdf_file = trifinger_simulation.finger_types_data.get_finger_urdf("trifingerpro")
     finger_urdf_path = os.path.join(robot_properties_path, "urdf", urdf_file)
     kinematics = trifinger_simulation.pinocchio_utils.Kinematics(
         finger_urdf_path,
@@ -53,9 +47,7 @@ def loop(win, args):
     try:
         while True:
             steps = 200
-            joint_pos_step_size = (
-                target_joint_pos - current_joint_pos
-            ) / steps
+            joint_pos_step_size = (target_joint_pos - current_joint_pos) / steps
 
             for _ in range(50):
                 current_joint_pos += joint_pos_step_size
@@ -65,9 +57,7 @@ def loop(win, args):
 
             gui.update_screen(
                 [
-                    "Center: ({:.3f}, {:.3f}, {:.3f})".format(
-                        *center_position
-                    ),
+                    "Center: ({:.3f}, {:.3f}, {:.3f})".format(*center_position),
                     "Tips to Center: {:.3f}".format(dist_tips_to_center),
                     "",
                 ]

--- a/scripts/construct_object_reset_trajectory.py
+++ b/scripts/construct_object_reset_trajectory.py
@@ -299,14 +299,10 @@ def main():
     swipes_120 = connect_swipes(initial_pos_120, swipes_120, jump_speed_mps)
     swipes_240 = connect_swipes(initial_pos_240, swipes_240, jump_speed_mps)
 
-    joint_trajectory = trajectory_ik(
-        swipes_0, swipes_120, swipes_240, args.visualize
-    )
+    joint_trajectory = trajectory_ik(swipes_0, swipes_120, swipes_240, args.visualize)
 
     header = ["observation_position_%d" % i for i in range(9)]
-    np.savetxt(
-        args.out_file, joint_trajectory, header=" ".join(header), comments=""
-    )
+    np.savetxt(args.out_file, joint_trajectory, header=" ".join(header), comments="")
 
 
 if __name__ == "__main__":

--- a/scripts/demonstrate_trajectory.py
+++ b/scripts/demonstrate_trajectory.py
@@ -103,9 +103,7 @@ def loop(win, args):
                 return
             elif pressed_key == ord(" "):
                 if is_recording:
-                    robot.logger.stop_and_save(
-                        args.outfile, robot.logger.Format.CSV
-                    )
+                    robot.logger.stop_and_save(args.outfile, robot.logger.Format.CSV)
                 else:
                     robot.logger.start()
 
@@ -122,9 +120,7 @@ def main():
         choices=robot_fingers.Robot.get_supported_robots(),
         help="Name of the robot.",
     )
-    parser.add_argument(
-        "outfile", type=str, help="Output file for the recorded data."
-    )
+    parser.add_argument("outfile", type=str, help="Output file for the recorded data.")
     args = parser.parse_args()
 
     curses.wrapper(lambda stdscr: loop(stdscr, args))

--- a/scripts/evaluate_log.py
+++ b/scripts/evaluate_log.py
@@ -14,9 +14,7 @@ from trifinger_simulation.camera import load_camera_parameters
 def compute_reward_move_cube(task, log, t, goal):
     camera_observation = log.get_camera_observation(t)
     cube_pose = camera_observation.filtered_object_pose
-    reward = -task.evaluate_state(
-        goal["goal"], cube_pose, int(goal["difficulty"])
-    )
+    reward = -task.evaluate_state(goal["goal"], cube_pose, int(goal["difficulty"]))
     return reward
 
 
@@ -27,9 +25,7 @@ def compute_reward_move_cube_on_trajectory(task, log, t, goal):
     return reward
 
 
-def compute_reward_rearrange_dice(
-    task, log, t, goal, goal_masks, reward_cache
-):
+def compute_reward_rearrange_dice(task, log, t, goal, goal_masks, reward_cache):
     camera_observation = log.get_camera_observation(t)
     # use timestamp of the first camera to identify the observation
     stamp = camera_observation.cameras[0].timestamp
@@ -37,8 +33,7 @@ def compute_reward_rearrange_dice(
     # only compute the reward if it is not yet in the cache
     if stamp not in reward_cache:
         masks = tuple(
-            segment_image(convert_image(c.image))
-            for c in camera_observation.cameras
+            segment_image(convert_image(c.image)) for c in camera_observation.cameras
         )
         reward_cache[stamp] = -task.evaluate_state(goal_masks, masks)
 
@@ -111,9 +106,7 @@ def main():
         camera_log = str(args.log_dir / "camera_data.dat")
 
         if args.task in ("move_cube", "move_cube_on_trajectory"):
-            log = robot_fingers.TriFingerPlatformWithObjectLog(
-                robot_log, camera_log
-            )
+            log = robot_fingers.TriFingerPlatformWithObjectLog(robot_log, camera_log)
         else:
             log = robot_fingers.TriFingerPlatformLog(robot_log, camera_log)
     except Exception as e:

--- a/scripts/fingeredu_endurance_test.py
+++ b/scripts/fingeredu_endurance_test.py
@@ -56,16 +56,11 @@ def main():
     )
 
     finger_data = robot_interfaces.finger.SingleProcessData()
-    backend = robot_fingers.create_real_finger_backend(
-        finger_data, config_file_path
-    )
+    backend = robot_fingers.create_real_finger_backend(finger_data, config_file_path)
     finger = robot_interfaces.finger.Frontend(finger_data)
     backend.initialize()
 
-    input(
-        "Verify that finger is pointing straight down."
-        "  Press Enter to continue."
-    )
+    input("Verify that finger is pointing straight down." "  Press Enter to continue.")
 
     demo_position_commands(finger)
 

--- a/scripts/fingerpro_endurance_test.py
+++ b/scripts/fingerpro_endurance_test.py
@@ -184,9 +184,7 @@ def move_on_full_range(push_interval):
     config.soft_position_limits_upper = [np.inf] * n_joints
 
     robot_data = robot_interfaces.finger.SingleProcessData()
-    robot_backend = robot_fingers.create_real_finger_backend(
-        robot_data, config
-    )
+    robot_backend = robot_fingers.create_real_finger_backend(robot_data, config)
     robot_frontend = robot_interfaces.finger.Frontend(robot_data)
 
     robot_backend.initialize()

--- a/scripts/joint_friction_calibration.py
+++ b/scripts/joint_friction_calibration.py
@@ -111,9 +111,7 @@ def run_application(stdscr, robot, velocity_radps, buffer_size):
 
             line += 2
             stdscr.addstr(line, 0, "Status:", curses.A_BOLD)
-            stdscr.addstr(
-                line, len("Status:") + 1, "RUNNING" if enabled else "STOPPED"
-            )
+            stdscr.addstr(line, len("Status:") + 1, "RUNNING" if enabled else "STOPPED")
 
             line += 2
             stdscr.addstr(line, 0, "Commanded Torque:", curses.A_BOLD)
@@ -140,16 +138,12 @@ def run_application(stdscr, robot, velocity_radps, buffer_size):
                 )
 
             line += 2
-            stdscr.addstr(
-                line, 0, "Velocity (actual / desired):", curses.A_BOLD
-            )
+            stdscr.addstr(line, 0, "Velocity (actual / desired):", curses.A_BOLD)
             for i, (p, d) in enumerate(
                 zip(velocity_buffer.mean(), desired_velocity_radps)
             ):
                 line += 1
-                stdscr.addstr(
-                    line, 4, "Joint {}: {:.3f} / {:3f}".format(i, p, d)
-                )
+                stdscr.addstr(line, 4, "Joint {}: {:.3f} / {:3f}".format(i, p, d))
 
             stdscr.refresh()
 

--- a/scripts/plot_post_submission_log.py
+++ b/scripts/plot_post_submission_log.py
@@ -47,9 +47,7 @@ def read_file(filename):
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "logfiles", nargs="+", type=pathlib.Path, help="logfiles"
-    )
+    parser.add_argument("logfiles", nargs="+", type=pathlib.Path, help="logfiles")
     parser.add_argument(
         "--no-display",
         dest="use_display",
@@ -75,9 +73,7 @@ def main():
         position_displacement = [
             np.linalg.norm(s["position"]["mean"][:2]) for s in data
         ]
-        mean_confidence = [
-            s["confidence"]["object_mean_confidence"] for s in data
-        ]
+        mean_confidence = [s["confidence"]["object_mean_confidence"] for s in data]
         position_mean_error = [s["position"]["mean_error"] for s in data]
         orientation_mean_error = [s["orientation"]["mean_error"] for s in data]
 

--- a/scripts/plot_run_duration_log.py
+++ b/scripts/plot_run_duration_log.py
@@ -12,9 +12,7 @@ import matplotlib.dates
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "logfile", type=pathlib.Path, help="Path to the logfile."
-    )
+    parser.add_argument("logfile", type=pathlib.Path, help="Path to the logfile.")
     args = parser.parse_args()
 
     data = np.loadtxt(args.logfile)

--- a/scripts/position_control_on_off.py
+++ b/scripts/position_control_on_off.py
@@ -53,9 +53,7 @@ class CursesGUI:
             # header line
             line = 0
             if position_control_enabled:
-                self.win.addstr(
-                    line, 0, "Position Control Enabled", curses.A_BOLD
-                )
+                self.win.addstr(line, 0, "Position Control Enabled", curses.A_BOLD)
             else:
                 self.win.addstr(line, 0, "Position Control Disabled")
             line += 3

--- a/scripts/pybullet_backend.py
+++ b/scripts/pybullet_backend.py
@@ -84,9 +84,7 @@ def main():
     node = NotificationNode("trifinger_backend")
     logger = node.get_logger()
 
-    robot_data = robot_interfaces.trifinger.MultiProcessData(
-        "trifinger", False
-    )
+    robot_data = robot_interfaces.trifinger.MultiProcessData("trifinger", False)
 
     backend = drivers.create_trifinger_backend(
         robot_data,

--- a/scripts/robot_log_dat2csv.py
+++ b/scripts/robot_log_dat2csv.py
@@ -41,9 +41,7 @@ def main():
 
     for action_type in ("applied_action", "desired_action"):
         for field in ("torque", "position", "position_kp", "position_kd"):
-            header += [
-                "%s_%s_%d" % (action_type, field, i) for i in range(n_joints)
-            ]
+            header += ["%s_%s_%d" % (action_type, field, i) for i in range(n_joints)]
 
     print("Convert log file")
     progress = progressbar.ProgressBar()

--- a/scripts/run_onejoint_tests.py
+++ b/scripts/run_onejoint_tests.py
@@ -102,8 +102,7 @@ def hit_endstop(robot, desired_torque, hold=0, timeout=5000):
     t = robot.append_desired_action(action)
 
     while (
-        np.any(np.abs(robot.get_observation(t).velocity) > zero_velocity)
-        or step < 100
+        np.any(np.abs(robot.get_observation(t).velocity) > zero_velocity) or step < 100
     ) and step < timeout:
         t = robot.append_desired_action(action)
 
@@ -276,9 +275,7 @@ def main():
             hard_direction_change(robot, 2, trq)
 
             t = robot.get_current_timeindex()
-            if np.any(
-                np.abs(robot.get_observation(t).position) > POSITION_LIMIT
-            ):
+            if np.any(np.abs(robot.get_observation(t).position) > POSITION_LIMIT):
                 print("ERROR: Position limit exceeded!")
                 return
 

--- a/scripts/single_finger_test.py
+++ b/scripts/single_finger_test.py
@@ -52,9 +52,7 @@ class CursesGUI:
 
             # header line
             line = 0
-            self.win.addstr(
-                line, 0, "Single Finger Test Application", curses.A_BOLD
-            )
+            self.win.addstr(line, 0, "Single Finger Test Application", curses.A_BOLD)
             line += 3
 
             # draw the data tables
@@ -66,9 +64,7 @@ class CursesGUI:
                 ["Position [rad]", "Velocity [rad/s]", "Torque [Nm]"],
                 motor_observation_data,
             )
-            self.win.addstr(
-                line, 0, "Tip Force: {}".format(observation.tip_force)
-            )
+            self.win.addstr(line, 0, "Tip Force: {}".format(observation.tip_force))
             line += 1
             line += 2
 
@@ -103,9 +99,7 @@ class CursesGUI:
                 "Action Repetitions: {}".format(status.action_repetitions),
             )
             line += 1
-            self.win.addstr(
-                line, 0, "Error Status: {}".format(status.error_status)
-            )
+            self.win.addstr(line, 0, "Error Status: {}".format(status.error_status))
             line += 1
             self.win.addstr(
                 line, 0, "Error Message: {}".format(status.get_error_message())
@@ -170,9 +164,7 @@ class CursesGUI:
 
         column_margin = 3
         if column_width is None:
-            column_width = (
-                max((len(h) for h in column_headers)) + column_margin
-            )
+            column_width = max((len(h) for h in column_headers)) + column_margin
 
         first_column_width = max((len(h) for h in row_headers)) + column_margin
 
@@ -249,9 +241,7 @@ def main():
             "config",
             "single_finger_test.yml",
         )
-        backend = robot_fingers.create_real_finger_backend(
-            robot_data, config_file_path
-        )
+        backend = robot_fingers.create_real_finger_backend(robot_data, config_file_path)
 
     frontend = finger.Frontend(robot_data)
     backend.initialize()

--- a/scripts/trifinger_backend.py
+++ b/scripts/trifinger_backend.py
@@ -126,18 +126,14 @@ def parse_arguments() -> argparse.Namespace:
 
     # logging is only possible with fixed number of actions (otherwise it is
     # not possible to decide the logger buffer size)
-    if (
-        args.robot_logfile or args.camera_logfile
-    ) and not args.max_number_of_actions:
+    if (args.robot_logfile or args.camera_logfile) and not args.max_number_of_actions:
         parser.error(
-            "--max-number-of-actions must be specified when using data"
-            " logging."
+            "--max-number-of-actions must be specified when using data" " logging."
         )
 
     if not args.config_dir.is_dir():
         parser.error(
-            "--config-dir: %s does not exist or is not a directory"
-            % args.config_dir
+            "--config-dir: %s does not exist or is not a directory" % args.config_dir
         )
 
     # === configure logging
@@ -260,9 +256,7 @@ def main() -> int:
         pathlib.Path(args.ready_indicator).unlink()
 
     if cameras_enabled and args.camera_logfile:
-        logging.info(
-            "Save recorded camera data to file %s", args.camera_logfile
-        )
+        logging.info("Save recorded camera data to file %s", args.camera_logfile)
         camera_logger.stop_and_save(args.camera_logfile)
 
     if args.robot_logfile:

--- a/scripts/trifinger_data_backend.py
+++ b/scripts/trifinger_data_backend.py
@@ -114,9 +114,7 @@ def main():
         # wait for first action to be sent by the user (but make sure to not
         # block when shutdown is requested)
         while (
-            not robot_data.desired_action.wait_for_timeindex(
-                0, max_duration_s=1
-            )
+            not robot_data.desired_action.wait_for_timeindex(0, max_duration_s=1)
             and not node.shutdown_requested
         ):
             rclpy.spin_once(node, timeout_sec=0)
@@ -130,9 +128,7 @@ def main():
     logger.debug("Received shutdown signal")
 
     if cameras_enabled and args.camera_logfile:
-        logger.info(
-            "Save recorded camera data to file %s" % args.camera_logfile
-        )
+        logger.info("Save recorded camera data to file %s" % args.camera_logfile)
         camera_logger.stop_and_save(args.camera_logfile)
 
     if args.robot_logfile:

--- a/scripts/trifinger_robot_backend.py
+++ b/scripts/trifinger_robot_backend.py
@@ -104,9 +104,7 @@ def main():
     config_file_path = "/etc/trifingerpro/trifingerpro.yml"
 
     # Storage for all observations, actions, etc.
-    robot_data = robot_interfaces.trifinger.MultiProcessData(
-        "trifinger", False
-    )
+    robot_data = robot_interfaces.trifinger.MultiProcessData("trifinger", False)
 
     # The backend sends actions from the data to the robot and writes
     # observations from the robot to the data.

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -90,9 +90,7 @@ def load_object_type() -> typing.Optional[str]:
         return None
 
 
-def get_robot_config_without_position_limits() -> (
-    robot_fingers.TriFingerConfig
-):
+def get_robot_config_without_position_limits() -> robot_fingers.TriFingerConfig:
     """Get TriFingerPro configuration without position limits.
 
     Loads the TriFingerPro configuration from the default config file and
@@ -130,9 +128,7 @@ def end_stop_check(robot: robot_fingers.Robot, log: logging.Logger) -> None:
         log: Logger instance to log results.
     """
     # go to the "homing" end-stop (using the same torque as during homing)
-    action = robot.Action(
-        torque=robot.config.calibration.endstop_search_torques_Nm
-    )
+    action = robot.Action(torque=robot.config.calibration.endstop_search_torques_Nm)
     for _ in range(2000):
         t = robot.frontend.append_desired_action(action)
         robot.frontend.wait_until_timeindex(t)
@@ -152,10 +148,7 @@ def end_stop_check(robot: robot_fingers.Robot, log: logging.Logger) -> None:
 
     observation = robot.frontend.get_observation(t)
 
-    if (
-        np.linalg.norm(_zero_to_endstop - observation.position)
-        > _position_tolerance
-    ):
+    if np.linalg.norm(_zero_to_endstop - observation.position) > _position_tolerance:
         log.error(
             SM(
                 "End stop not at expected position.",
@@ -611,9 +604,7 @@ def main():
     log = logging.getLogger()
     log.setLevel(logging.NOTSET)
     stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.setFormatter(
-        logging.Formatter("%(levelname)s - %(message)s")
-    )
+    stdout_handler.setFormatter(logging.Formatter("%(levelname)s - %(message)s"))
     stdout_handler.setLevel(logging.INFO)
     log.addHandler(stdout_handler)
     if args.logfile:
@@ -655,9 +646,7 @@ def main():
     if args.reset:
         if args.object == "cube":
             print("Reset cube position")
-            reset_object(
-                robot, "trifingerpro_shuffle_cube_trajectory_fast.csv"
-            )
+            reset_object(robot, "trifingerpro_shuffle_cube_trajectory_fast.csv")
         elif args.object == "cuboid":
             print("Reset cuboid position")
             reset_object(robot, "trifingerpro_recenter_cuboid_2x2x8.csv")
@@ -669,9 +658,7 @@ def main():
     del robot
 
     print("Check cameras")
-    camera_observations = record_camera_observations(
-        args.object, num_observations=30
-    )
+    camera_observations = record_camera_observations(args.object, num_observations=30)
 
     if not check_camera_brightness(
         camera_observations, logging.getLogger("camera_brightness")

--- a/test/test_pybullet_backend.py
+++ b/test/test_pybullet_backend.py
@@ -25,20 +25,14 @@ class TestPyBulletBackend(unittest.TestCase):
         num_fingers = finger_types_data.get_number_of_fingers(finger_type)
         if num_fingers == 1:
             finger_types = robot_interfaces.finger
-            create_backend = (
-                robot_fingers.pybullet_drivers.create_single_finger_backend
-            )
+            create_backend = robot_fingers.pybullet_drivers.create_single_finger_backend
         elif num_fingers == 3:
             finger_types = robot_interfaces.trifinger
-            create_backend = (
-                robot_fingers.pybullet_drivers.create_trifinger_backend
-            )
+            create_backend = robot_fingers.pybullet_drivers.create_trifinger_backend
 
         robot_data = finger_types.SingleProcessData()
 
-        backend = create_backend(
-            robot_data, real_time_mode=False, visualize=False
-        )
+        backend = create_backend(robot_data, real_time_mode=False, visualize=False)
 
         frontend = finger_types.Frontend(robot_data)
         backend.initialize()
@@ -52,9 +46,7 @@ class TestPyBulletBackend(unittest.TestCase):
 
             # check if desired position is reached
             current_position = frontend.get_observation(t).position
-            np.testing.assert_array_almost_equal(
-                goal, current_position, decimal=1
-            )
+            np.testing.assert_array_almost_equal(goal, current_position, decimal=1)
 
     def test_single_finger_position_control(self):
         """Test position control for the simulated single finger."""


### PR DESCRIPTION
## Description
Change the maximum line length for Python from 79 to 88 (default of black and ruff).

- Change the config files for the corresponding tools (black, ruff, flake8)
- Reformat everything with black.

Also add a workflow_dispatch trigger to the build_master workflow.

