### PR TITLE
Add min_jerk_trajectory() and improve self-test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   if a lens comes loose.
 - Check camera brightness in `trifinger_post_submission.py` to auto-detect
   broken light panels.
+- Python generator `utils.min_jerk_trajectory` for arbitrary min. jerk trajectories.
 
 ### Changed
 - Upgrade to robot_interfaces v2 (not yet released).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 - `trifinger_backend`: Use proper timeseries history length if no limit for
   number of actions is specified.
 - pybind11 build error on Ubuntu 22.04
+- Improve the push sensor test in `trifinger_post_submission` to avoid frequent
+  false positives.
 
 
 ## [1.0.0] - 2022-06-28

--- a/demos/demo_trifingerpro.py
+++ b/demos/demo_trifingerpro.py
@@ -8,33 +8,52 @@ import argparse
 
 import robot_interfaces
 import robot_fingers
+from robot_fingers.utils import min_jerk_trajectory
 
 
 def run_choreography(frontend):
     """Move the legs in some hard-coded choreography."""
 
-    def perform_step(position):
+    def perform_step(start, goal):
         # one step should take 1 second, so repeat action 1000 times
-        for _ in range(1000):
+        STEPS = 1000
+
+        # use min_jerk_trajectory to generate smooth trajectories (we could also just
+        # use `Action(position=goal)` and append that for several steps until the goal
+        # is reached but it would result in harsher movements).
+        for step_position in min_jerk_trajectory(start, goal, STEPS):
             t = frontend.append_desired_action(
-                robot_interfaces.trifinger.Action(position=position)
+                robot_interfaces.trifinger.Action(position=step_position)
             )
             frontend.wait_until_timeindex(t)
 
-    pose_initial = [0, 0.9, -1.7]
-    pose_intermediate = [0.75, 1.2, -2.3]
-    pose_up = [1.3, 1.5, -2.6]
-    pose_other_side_up = [-0.8, 1.5, -1.7]
+        # return final position
+        observation = frontend.get_observation(t)
+        return observation.position
+
+    # Desired joint positions for the steps.  Specify for a single finger and multiply
+    # by 3, so we get a list of length 9 with identical joint positions for all three
+    # fingers.
+    pose_initial = [0, 0.9, -1.7] * 3
+    pose_intermediate = [0.75, 1.2, -2.3] * 3
+    pose_up = [1.3, 1.5, -2.6] * 3
+    pose_other_side_up = [-0.8, 1.5, -1.7] * 3
 
     time_printer = robot_fingers.utils.TimePrinter()
 
+    # send a zero-torque action to start the backend loop, so we can get the initial
+    # position
+    t = frontend.append_desired_action(robot_interfaces.trifinger.Action())
+    observation = frontend.get_observation(t)
+    current_position = observation.position
+
     while True:
         # initial pose
-        perform_step(pose_initial * 3)
-        perform_step(pose_intermediate * 3)
-        perform_step(pose_up * 3)
-        perform_step(pose_initial * 3)
-        perform_step(pose_other_side_up * 3)
+        current_position = perform_step(current_position, pose_initial)
+        current_position = perform_step(current_position, pose_intermediate)
+        current_position = perform_step(current_position, pose_up)
+        current_position = perform_step(current_position, pose_initial)
+        current_position = perform_step(current_position, pose_other_side_up)
 
         # print current date/time every hour, so we can roughly see how long it
         # ran in case it crashes during a long-run-test.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,3 +36,45 @@ module = [
 ]
 ignore_missing_imports = true
 
+
+[tool.ruff]
+# enable all and disable a few via ignore below
+select = ["ALL"]
+extend-ignore = [
+    "BLE",
+    "COM",
+    "EM",
+    "FBT",
+    "INP",
+    "PTH",
+    "S",
+    "T20",
+    "UP",
+    "A003",
+    "ANN101",
+    "ANN102",
+    "ANN401",
+    "D105",
+    "D107",
+    "D205",
+    "D212",
+    "D417",
+    "G004",
+    "I001",
+    "N806",
+    "PLR0913",
+    "PTH123",
+    "RET505",
+    "TRY003",
+    "TRY400",
+]
+target-version = "py310"
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.per-file-ignores]
+"*.pyi" = ["ALL"]
+"__init__.py" = ["F401"]  # unused imports
+"test/*" = ["D", "ANN", "PLR2004"]
+"scripts/*" = ["D"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ module = [
     "pinocchio",
     "plotext",
     "progressbar",
+    "pytest",
     "rclpy.*",
     "scipy.*",
     "setuptools",

--- a/robot_fingers/utils.py
+++ b/robot_fingers/utils.py
@@ -1,12 +1,14 @@
+"""Utility classes/functions for the robot_fingers package."""
 import time
+
+import numpy as np
+import numpy.typing as npt
 
 
 class TimePrinter:
-    """
-    Regularly print the current date/time and the passed duration in hours.
-    """
+    """Regularly print the current date/time and the passed duration in hours."""
 
-    def __init__(self, interval_s: float = 3600.0):
+    def __init__(self, interval_s: float = 3600.0) -> None:
         """Initialise.
 
         Args:
@@ -20,7 +22,7 @@ class TimePrinter:
 
         self._last_time_print = 0.0
 
-    def update(self):
+    def update(self) -> None:
         """Print time if the interval_s has passed since the last call."""
         now = time.time()
         if now - self._last_time_print > self.interval_s:
@@ -30,3 +32,36 @@ class TimePrinter:
                 "{} ({} h since {})".format(time_str, duration_h, self.start_time_str)
             )
             self._last_time_print = now
+
+
+def min_jerk_trajectory(
+    start_position: npt.ArrayLike, end_position: npt.ArrayLike, num_steps: int
+) -> npt.NDArray:
+    """Generator for computing minimum jerk trajectories.
+
+    Example:
+        To move from ``[0, 0, 0]`` to ``[1, 2, 3]`` over 1000 time steps:
+
+        .. code-block:: Python
+
+            for pos in min_jerk_trajectory([0, 0, 0], [1, 2, 3], 1000):
+                robot.append_desired_action(Action(position=pos)
+
+    Args:
+        start_position: Joint positions where the trajectory starts.
+        end_position: Joint positions where the trajectory ends.
+        num_steps: Number of steps for the trajectory.
+    """
+    if num_steps < 1:
+        raise ValueError("num_steps must be >= 1")
+
+    start_position = np.asarray(start_position)
+    end_position = np.asarray(end_position)
+    position_delta = end_position - start_position
+
+    for t in range(num_steps):
+        alpha = t / num_steps
+        step_position = start_position + position_delta * (
+            10.0 * alpha**3 - 15.0 * alpha**4 + 6.0 * alpha**5
+        )
+        yield step_position

--- a/robot_fingers/utils.py
+++ b/robot_fingers/utils.py
@@ -60,8 +60,8 @@ def min_jerk_trajectory(
     end_position = np.asarray(end_position)
     position_delta = end_position - start_position
 
-    for t in range(num_steps):
-        alpha = t / num_steps
+    for i in range(num_steps):
+        alpha = i / num_steps
         step_position = start_position + position_delta * (
             10.0 * alpha**3 - 15.0 * alpha**4 + 6.0 * alpha**5
         )

--- a/robot_fingers/utils.py
+++ b/robot_fingers/utils.py
@@ -1,5 +1,6 @@
 """Utility classes/functions for the robot_fingers package."""
 import time
+import typing as t
 
 import numpy as np
 import numpy.typing as npt
@@ -36,7 +37,7 @@ class TimePrinter:
 
 def min_jerk_trajectory(
     start_position: npt.ArrayLike, end_position: npt.ArrayLike, num_steps: int
-) -> npt.NDArray:
+) -> t.Iterator[npt.NDArray]:
     """Generator for computing minimum jerk trajectories.
 
     Example:

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -239,7 +239,7 @@ def run_self_test(robot: robot_fingers.Robot, log: logging.Logger) -> None:
     no_contact_tip_force = observation.tip_force
 
     for goal in reachable_goals:
-        for _position in min_jerk_trajectory(observation.position, goal, 1000):
+        for _position in min_jerk_trajectory(observation.position, goal, 700):
             action = robot.Action(position=_position)
             t = robot.frontend.append_desired_action(action)
             robot.frontend.wait_until_timeindex(t)
@@ -260,13 +260,13 @@ def run_self_test(robot: robot_fingers.Robot, log: logging.Logger) -> None:
 
     for goal in unreachable_goals:
         # move to initial position first
-        for _position in min_jerk_trajectory(observation.position, initial_pose, 1000):
+        for _position in min_jerk_trajectory(observation.position, initial_pose, 700):
             action = robot.Action(position=_position)
             t = robot.frontend.append_desired_action(action)
             robot.frontend.wait_until_timeindex(t)
         observation = robot.frontend.get_observation(t)
 
-        for _position in min_jerk_trajectory(observation.position, goal, 1000):
+        for _position in min_jerk_trajectory(observation.position, goal, 700):
             action = robot.Action(position=_position)
             t = robot.frontend.append_desired_action(action)
             robot.frontend.wait_until_timeindex(t)

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -208,7 +208,7 @@ def run_self_test(robot: robot_fingers.Robot, log: logging.Logger) -> None:
         current_tip_force: npt.NDArray,
         no_contact_reference: npt.NDArray,
     ) -> bool:
-        contact_delta_threshold = 0.2
+        contact_delta_threshold = 0.1
         reference_delta = current_tip_force - no_contact_reference
         return any(reference_delta > contact_delta_threshold)
 

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -317,6 +317,14 @@ def reset_object(robot, trajectory_file):
     # extract the positions from the recorded data
     positions = data[data_keys].to_numpy()
 
+    # move to start position with a smooth trajectory
+    t = robot.frontend.get_current_timeindex()
+    observation = robot.frontend.get_observation(t)
+    for _position in min_jerk_trajectory(observation.position, positions[0], 700):
+        action = robot.Action(position=_position)
+        t = robot.frontend.append_desired_action(action)
+        robot.frontend.wait_until_timeindex(t)
+
     for position in positions:
         action = robot.Action(position=position)
         t = robot.frontend.append_desired_action(action)

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -253,6 +253,7 @@ def run_self_test(robot: robot_fingers.Robot, log: logging.Logger) -> None:
                 log,
                 "Push sensor reports high value in non-contact situation.",
                 sensor_value=observation.tip_force,
+                no_contact_reference=no_contact_tip_force,
                 desired_position=goal,
                 actual_position=observation.position,
             )
@@ -285,6 +286,7 @@ def run_self_test(robot: robot_fingers.Robot, log: logging.Logger) -> None:
                 log,
                 "Push sensor reports low value in contact situation.",
                 sensor_value=observation.tip_force,
+                no_contact_reference=no_contact_tip_force,
                 desired_position=goal,
                 actual_position=observation.position,
             )

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,48 @@
+import pytest
+import numpy as np
+
+from robot_fingers import utils
+
+
+def test_min_jerk_trajectory():
+    start = [0.0, 1.0]
+    end = [2.0, 2.0]
+    steps = 5
+    expected_steps = [
+        [0.0, 1.0],
+        [0.11584, 1.05792],
+        [0.63488, 1.31744],
+        [1.36512, 1.68256],
+        [1.88416, 1.94208],
+        [2.0, 2.0],
+    ]
+
+    traj = utils.min_jerk_trajectory(start, end, steps)
+    np.testing.assert_array_almost_equal(expected_steps[0], next(traj))
+    np.testing.assert_array_almost_equal(expected_steps[1], next(traj))
+    np.testing.assert_array_almost_equal(expected_steps[2], next(traj))
+    np.testing.assert_array_almost_equal(expected_steps[3], next(traj))
+    np.testing.assert_array_almost_equal(expected_steps[4], next(traj))
+    with pytest.raises(StopIteration):
+        next(traj)
+
+    # try again but using numpy arrays as input
+    traj = utils.min_jerk_trajectory(np.array(start), np.array(end), steps)
+    np.testing.assert_array_almost_equal(expected_steps[0], next(traj))
+    np.testing.assert_array_almost_equal(expected_steps[1], next(traj))
+    np.testing.assert_array_almost_equal(expected_steps[2], next(traj))
+    np.testing.assert_array_almost_equal(expected_steps[3], next(traj))
+    np.testing.assert_array_almost_equal(expected_steps[4], next(traj))
+    with pytest.raises(StopIteration):
+        next(traj)
+
+
+def test_min_jerk_trajectory__invalid_inputs():
+    with pytest.raises(ValueError, match="num_steps must be >= 1"):
+        next(utils.min_jerk_trajectory([0, 0], [1, 1], 0))
+
+    with pytest.raises(ValueError, match="num_steps must be >= 1"):
+        next(utils.min_jerk_trajectory([0, 0], [1, 1], -10))
+
+    with pytest.raises(ValueError, match="shapes"):
+        next(utils.min_jerk_trajectory([0, 0], [1, 1, 1], 10))


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

- Add Python generator `min_jerk_trajectory()` (in `utils` module) to easily compute smooth trajectories.  Use it in trifingerpro demo and in self test.
- trifingerpro_post_submission: Use a non-contact reference value for testing the push sensors instead of just comparing to a hard-coded threshold.  This should reduce the likelihood of false positives.
- trifingerpro_post_submission: Speed up a bit and smoothly move to start of reset trajectory to avoid jerky movements.


## How I Tested

on a robot.