### PR TITLE
Some improvements of trifingerpro_post_submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Check camera brightness in `trifinger_post_submission.py` to auto-detect
   broken light panels.
 - Python generator `utils.min_jerk_trajectory` for arbitrary min. jerk trajectories.
+- Add flag to `trifinger_post_submission.py` to make push sensor test fatal (disabled by
+  default).
 
 ### Changed
 - Upgrade to robot_interfaces v2 (not yet released).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@
 - Check camera brightness in `trifinger_post_submission.py` to auto-detect
   broken light panels.
 - Python generator `utils.min_jerk_trajectory` for arbitrary min. jerk trajectories.
-- Add flag to `trifinger_post_submission.py` to make push sensor test fatal (disabled by
-  default).
+- Add flags to `trifinger_post_submission.py` to make push sensor test fatal (disabled
+  by default) and to set the threshold for the test.
+- Add flag to `trifinger_post_submission.py` to skip camera tests.
 
 ### Changed
 - Upgrade to robot_interfaces v2 (not yet released).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,7 @@ extend-ignore = [
     "PLR0913",
     "PTH123",
     "RET505",
+    "SIM108",
     "TRY003",
     "TRY400",
 ]

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -718,6 +718,11 @@ def main():
         help="Skip the robot self-test.",
     )
     parser.add_argument(
+        "--skip-camera-test",
+        action="store_true",
+        help="Skip the camera self-test.",
+    )
+    parser.add_argument(
         "--fatal-push-sensor-test",
         action="store_true",
         help="""Fail self-test if the push-sensor test fails.  This test has a high
@@ -778,8 +783,8 @@ def main():
         run_self_test(
             robot,
             logging.getLogger("self_test"),
-            args.fatal_push_sensor_test,
-            args.push_sensor_threshold,
+            fatal_push_sensor_test=args.fatal_push_sensor_test,
+            push_sensor_threshold=args.push_sensor_threshold,
         )
 
     if args.reset:
@@ -796,27 +801,30 @@ def main():
     # terminate the robot
     del robot
 
-    print("Check cameras")
-    camera_observations = record_camera_observations(args.object, num_observations=30)
+    if not args.skip_camera_test:
+        print("Check cameras")
+        camera_observations = record_camera_observations(
+            args.object, num_observations=30
+        )
 
-    if not check_camera_brightness(
-        camera_observations, logging.getLogger("camera_brightness")
-    ):
-        sys.exit(2)
-
-    if not check_camera_sharpness(
-        camera_observations, logging.getLogger("camera_sharpness")
-    ):
-        sys.exit(2)
-
-    if args.object in ["cube", "cuboid"]:
-        print("Check object detection")
-        if not check_object_detection_noise(
-            args.object,
-            camera_observations,
-            logging.getLogger("object_detection"),
+        if not check_camera_brightness(
+            camera_observations, logging.getLogger("camera_brightness")
         ):
             sys.exit(2)
+
+        if not check_camera_sharpness(
+            camera_observations, logging.getLogger("camera_sharpness")
+        ):
+            sys.exit(2)
+
+        if args.object in ["cube", "cuboid"]:
+            print("Check object detection")
+            if not check_object_detection_noise(
+                args.object,
+                camera_observations,
+                logging.getLogger("object_detection"),
+            ):
+                sys.exit(2)
 
 
 if __name__ == "__main__":

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -264,6 +264,15 @@ def run_self_test(
             )
             if fatal_push_sensor_test:
                 sys.exit(1)
+        else:
+            log.info(
+                SM(
+                    "Push sensor test passed (non-contact).",
+                    sensor_value=observation.tip_force,
+                    no_contact_reference=no_contact_tip_force,
+                    threshold=push_sensor_contact_delta_threshold,
+                )
+            )
 
     for goal in unreachable_goals:
         # move to initial position first
@@ -302,6 +311,15 @@ def run_self_test(
             )
             if fatal_push_sensor_test:
                 sys.exit(1)
+        else:
+            log.info(
+                SM(
+                    "Push sensor test passed (contact).",
+                    sensor_value=observation.tip_force,
+                    no_contact_reference=no_contact_tip_force,
+                    threshold=push_sensor_contact_delta_threshold,
+                )
+            )
 
     print("Test successful.")
 

--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -286,7 +286,11 @@ def _push_sensor_test(
 
 
 def run_self_test(
-    robot: robot_fingers.Robot, log: logging.Logger, /, fatal_push_sensor_test: bool
+    robot: robot_fingers.Robot,
+    log: logging.Logger,
+    *,
+    fatal_push_sensor_test: bool,
+    push_sensor_threshold: float,
 ) -> None:
     position_tolerance = 0.2
 
@@ -340,6 +344,7 @@ def run_self_test(
                 observation.position,
                 expect_contact=False,
                 log_error=fatal_push_sensor_test,
+                push_sensor_contact_delta_threshold=push_sensor_threshold,
             )
             and fatal_push_sensor_test
         ):
@@ -369,6 +374,7 @@ def run_self_test(
                 observation.position,
                 expect_contact=True,
                 log_error=fatal_push_sensor_test,
+                push_sensor_contact_delta_threshold=push_sensor_threshold,
             )
             and fatal_push_sensor_test
         ):
@@ -720,6 +726,12 @@ def main():
             warning and not result in failing the self-test.
         """,
     )
+    parser.add_argument(
+        "--push-sensor-threshold",
+        type=float,
+        default=0.1,
+        help="Threshold for the push sensor test.",
+    )
     args = parser.parse_args()
 
     # configure logger
@@ -764,7 +776,10 @@ def main():
         end_stop_check(robot, logging.getLogger("end_stop_test"))
         print("Position reachability test")
         run_self_test(
-            robot, logging.getLogger("self_test"), args.fatal_push_sensor_test
+            robot,
+            logging.getLogger("self_test"),
+            args.fatal_push_sensor_test,
+            args.push_sensor_threshold,
         )
 
     if args.reset:


### PR DESCRIPTION
## Description

It turned out that the new push sensor test still has frequent false positives (though fewer than before). So for now not fail the self-test due to push sensors by default but add flags to make the push sensor test fatal and also to change the threshold.  This allows us to adapt the test on the system without need to update the code all the time.
The results of the push sensor test is now also always logged (independent of success or failure), so we can let it run for a while and then monitor how the test performs and also whether the push sensor values drift over time.

Further refactor a bit and add a flag to skip the camera tests (for faster testing).


## How I Tested

By running it on one of the robots.