### PR TITLE
post_submission: Set edge mean threshold to 10

### DIFF
--- a/scripts/trifingerpro_post_submission.py
+++ b/scripts/trifingerpro_post_submission.py
@@ -530,7 +530,7 @@ def check_camera_sharpness(
         True if test is successful, False if there is any issue.
     """
     CAMERA_NAMES = ("camera60", "camera180", "camera300")
-    EDGE_MEAN_THRES = 12.0
+    EDGE_MEAN_THRES = 10.0
 
     edge_means: typing.List[typing.List[float]] = [[], [], []]
 


### PR DESCRIPTION


## Description

After changing the rest position, less of the robot is visible to the cameras while sampling images for the sharpness test.  Due to this, fewer edges are found, resulting in a lower "edge mean" value, even if the sharpness of the camera is good.
Thus reduce the threshold to 10 to avoid false positives.


## How I Tested

Not explicitly tested.  New value is based on values found in false positive self-test failures.