### PR TITLE
Do not hard-code camera frame rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@
 - Disable position limit checks during shutdown trajectory.  This allows setting
   the rest position of the TriFingerPro to a more suitable position which is
   outside of the operation limits.
+- Camera frame rate is not hard-coded anymore in `trifinger_data_backend` and
+  `trifinger_backend`.  Instead it is fetched from the camera settings
+  (`trifinger_data_backend`) or the camera driver directly (`trifinger_backend`).
 
 ### Fixed
 - Update demo_data_logging to changed interface of the RobotLogger class.

--- a/scripts/trifinger_data_backend.py
+++ b/scripts/trifinger_data_backend.py
@@ -85,7 +85,7 @@ def main() -> int:
 
         camera_settings = camera.Settings()
         camera_rate_hz = camera_settings.get_tricamera_driver_settings().frame_rate_fps
-        logger.debug("Loaded camera frame rate from settings: %f fps", camera_rate_hz)
+        logger.debug("Loaded camera frame rate from settings: %f fps" % camera_rate_hz)
 
         # make sure camera time series covers at least the same duration as the robot
         # time series (add some margin to avoid problems)
@@ -94,7 +94,7 @@ def main() -> int:
         camera_time_series_length = int(
             camera_rate_hz * time_series_length_seconds * length_margin_ratio
         )
-        logger.debug("Set camera time series length to %d", camera_time_series_length)
+        logger.debug("Set camera time series length to %d" % camera_time_series_length)
 
         camera_data = tricamera.MultiProcessData(
             "tricamera", True, camera_time_series_length
@@ -121,7 +121,7 @@ def main() -> int:
         # Compute camera log size based on number of robot actions plus some buffer
         log_size = int(camera_rate_hz * episode_length_s * buffer_length_factor)
 
-        logger.info("Initialize camera logger with buffer size %d", log_size)
+        logger.info("Initialize camera logger with buffer size %d" % log_size)
         camera_logger = tricamera.Logger(camera_data, log_size)
 
     logger.info("Data backend is ready")
@@ -147,11 +147,11 @@ def main() -> int:
     logger.debug("Received shutdown signal")
 
     if cameras_enabled and args.camera_logfile:
-        logger.info("Save recorded camera data to file %s", args.camera_logfile)
+        logger.info("Save recorded camera data to file %s" % args.camera_logfile)
         camera_logger.stop_and_save(args.camera_logfile)
 
     if args.robot_logfile:
-        logger.info("Save robot data to file %s", args.robot_logfile)
+        logger.info("Save robot data to file %s" % args.robot_logfile)
         robot_logger.stop_and_save(
             args.robot_logfile, robot_interfaces.trifinger.Logger.Format.BINARY
         )

--- a/scripts/trifinger_data_backend.py
+++ b/scripts/trifinger_data_backend.py
@@ -22,7 +22,7 @@ ROBOT_TIME_SERIES_LENGTH = 1000
 ROBOT_RATE_Hz = 1000
 
 
-def main():
+def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--max-number-of-actions",
@@ -60,6 +60,15 @@ def main():
         """,
     )
     args = parser.parse_args()
+
+    if args.camera_logfile and not (args.cameras or args.cameras_with_tracker):
+        parser.error("--camera-logfile requires --cameras or --cameras-with-tracker")
+
+    return args
+
+
+def main() -> int:
+    args = parse_args()
 
     rclpy.init()
     node = NotificationNode("trifinger_data")


### PR DESCRIPTION
## Description

Since the camera frame rate can be configured now, it should not be hard-coded anywhere.

- **trifinger_backend**: Here we can use `get_sensor_info()` of the driver to get its frame rate.
- **trifinger_data_backend**: Since the driver is not instantiated within this script, it's not possible to get the frame rate directly from it.  Instead, use the camera `Settings` class to read the settings and get the frame rate from there.  Note that this only works as long as the driver is using the default settings discovery and is not passed a file explicitly!


## How I Tested

By running the two scripts and checking the resulting timeseries/logger buffer sizes when changing the camera frame rate.