### PR TITLE
Use pytest instead of nose

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,11 +193,11 @@ install(
 
 # Tests
 if (BUILD_TESTING)
-    find_package(ament_cmake_nose REQUIRED)
+    find_package(ament_cmake_pytest REQUIRED)
     find_package(ament_cmake_gtest REQUIRED)
 
     # Python tests
-    ament_add_nose_test(test_pybullet_backend_py test/test_pybullet_backend.py)
+    ament_add_pytest_test(test_pybullet_backend_py test/test_pybullet_backend.py)
 
     # C++ tests
     ament_add_gtest(test_pybullet_backend

--- a/package.xml
+++ b/package.xml
@@ -28,7 +28,7 @@
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>trifinger_simulation</exec_depend>
 
-  <test_depend>ament_cmake_nose</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
 
   <export>


### PR DESCRIPTION
The ament_cmake_nose package apparently doesn't exist anymore in ROS Jazzy.  We anyway write new tests for pytest, so let's simply switch to that.
There should be no need to do any changes on the actual test as pytest can run them as well.
