### PR TITLE
Add TriFingerPlatformFrontendCameraSynced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@
   by default) and to set the threshold for the test.
 - Add flag to `trifinger_post_submission.py` to skip camera tests.
 - Support new object "stag_cube" in `pybullet_backend`.
+- `TriFingerPlatform*FrontendCameraSynced`: Very similar to `TriFingerPlatform*Frontend`
+  but uses camera time steps as base and provides for a given time step t the robot
+  observation that is closest in time to the timestamp of the images in the camera
+  observation t (i.e. the images and the robot observation are more or less from the
+  same moment).
 
 ### Changed
 - Upgrade to robot_interfaces v2 (not yet released).
@@ -34,6 +39,8 @@
 - Camera frame rate is not hard-coded anymore in `trifinger_data_backend` and
   `trifinger_backend`.  Instead it is fetched from the camera settings
   (`trifinger_data_backend`) or the camera driver directly (`trifinger_backend`).
+- `TriFingerPlatform*Frontend::get_timestamp_ms` is deprecated, use
+  `...::get_robot_timestamp_ms` instead.
 
 ### Fixed
 - Update demo_data_logging to changed interface of the RobotLogger class.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,18 +216,25 @@ if (BUILD_TESTING)
 
     # Create a usefull macro to build different unit tests suits.
     macro(add_cpp_test test_name)
+      cmake_parse_arguments(ADD_CPP_TEST "" "" "LINK_LIBRARIES" ${ARGN})
 
       set(test_target_name test_${test_name})
 
       # create the executable
       ament_add_gtest(${test_target_name} test/${test_target_name}.cpp)
+
       # Add the include dependencies.
       target_include_directories(
         ${test_target_name}
         PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
                $<INSTALL_INTERFACE:include>)
+
       # link the dependecies to it
       target_link_libraries(${test_target_name} ${PROJECT_NAME})
+      if (ADD_CPP_TEST_LINK_LIBRARIES)
+        target_link_libraries(${test_target_name} ${ADD_CPP_TEST_LINK_LIBRARIES})
+      endif()
+
       install(TARGETS ${test_target_name} DESTINATION lib/${PROJECT_NAME})
 
     endmacro()
@@ -235,6 +242,9 @@ if (BUILD_TESTING)
     add_cpp_test(process_action)
     add_cpp_test(n_joint_blmc_robot_driver)
     add_cpp_test(clamp)
+    add_cpp_test(trifinger_platform_frontend_camera_synced
+      LINK_LIBRARIES trifinger_platform_frontend
+    )
 
 endif()
 

--- a/include/robot_fingers/trifinger_platform_frontend.hpp
+++ b/include/robot_fingers/trifinger_platform_frontend.hpp
@@ -241,4 +241,247 @@ typedef T_TriFingerPlatformFrontend<
     TriFingerPlatformWithObjectFrontend;
 typedef T_TriFingerPlatformFrontend<trifinger_cameras::TriCameraObservation>
     TriFingerPlatformFrontend;
+
+///////////////////////////////////////////////////////////////
+
+/**
+ * @brief Combined front end for the TriFinger Platform, synchronizing robot
+ * observations with the camera.
+ *
+ * This class combines the frontends for robot and cameras in one class using
+ * unified time indices.
+ *
+ * It is similar to @ref T_TriFingerPlatformFrontend but uses the camera time steps as
+ * base for accessing observations.
+ *
+ * So methods for accessing robot observations/actions/status take as input a camera
+ * time step t_c and internally map it to the robot time step t_r which is closest to
+ * the moment when the images where fetched from the cameras (i.e. it uses the _image
+ * timestamps_ for synchronizing, not the timestamp of the _camera observation_).
+ *
+ * @todo Methods to get timestamp from camera or object tracker?
+ */
+template <typename CameraObservation_t>
+class T_TriFingerPlatformFrontendCameraSynced
+{
+public:
+    // typedefs for easy access
+    typedef robot_interfaces::TriFingerTypes::Action Action;
+    typedef robot_interfaces::TriFingerTypes::Observation RobotObservation;
+    typedef robot_interfaces::Status RobotStatus;
+    // typedef trifinger_object_tracking::TriCameraObjectObservation
+    //    CameraObservation;
+    typedef CameraObservation_t CameraObservation;
+
+    /**
+     * @brief Initialize with data instances for all internal frontends.
+     *
+     * @param robot_data  RobotData instance used by the robot frontend.
+     * @param object_tracker_data ObjectTrackerData instance used by the object
+     *     tracker frontend.
+     * @param camera_data SensorData instance, used by the camera frontend.
+     */
+    T_TriFingerPlatformFrontend(
+        robot_interfaces::TriFingerTypes::BaseDataPtr robot_data,
+        std::shared_ptr<robot_interfaces::SensorData<CameraObservation>>
+            camera_data)
+        : robot_frontend_(robot_data), camera_frontend_(camera_data)
+    {
+    }
+
+    /**
+     * @brief Initialize with default data instances.
+     *
+     * Creates for each internal frontend a corresponding mutli-process data
+     * instance with the default shared memory ID for the corresponding data
+     * type.
+     */
+    T_TriFingerPlatformFrontend()
+        : robot_frontend_(std::make_shared<
+                          robot_interfaces::TriFingerTypes::MultiProcessData>(
+              "trifinger", false)),
+          camera_frontend_(
+              std::make_shared<
+                  robot_interfaces::MultiProcessSensorData<CameraObservation>>(
+                  "tricamera", false))
+
+    {
+    }
+
+    /**
+     * @brief Append a desired robot action to the action queue.
+     * @see robot_interfaces::TriFingerTypes::Frontend::append_desired_action
+     *
+     * @return The index of the time step at which this action is going to be
+     *     executed.
+     */
+    time_series::Index append_desired_action(const Action &desired_action)
+    {
+        // FIXME what should this function return?
+        return robot_frontend_.append_desired_action(desired_action);
+    }
+
+    /**
+     * @brief Get robot observation matching images in camera time step t_camera.
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_observation
+     */
+    RobotObservation get_robot_observation(const time_series::Index &t_camera) const
+    {
+        auto t_robot = find_matching_robot_timeindex(t_camera);
+        return robot_frontend_.get_observation(t_robot);
+    }
+
+    /**
+     * @brief Get desired action matching images in camera time step t_camera.
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_desired_action
+     */
+    Action get_desired_action(const time_series::Index &t_camera) const
+    {
+        auto t_robot = find_matching_robot_timeindex(t_camera);
+        return robot_frontend_.get_desired_action(t_robot);
+    }
+
+    /**
+     * @brief Get actually applied action matching images in camera time step t_camera.
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_applied_action
+     */
+    Action get_applied_action(const time_series::Index &t_camera) const
+    {
+        auto t_robot = find_matching_robot_timeindex(t_camera);
+        return robot_frontend_.get_applied_action(t_robot);
+    }
+
+    /**
+     * @brief Get robot status matching images in camera time step t_camera.
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_status
+     */
+    RobotStatus get_robot_status(const time_series::Index &t_camera) const
+    {
+        auto t_robot = find_matching_robot_timeindex(t_camera);
+        return robot_frontend_.get_status(t_robot);
+    }
+
+    /**
+     * @brief Get timestamp (in milliseconds) matching images in camera time step t_camera.
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_timestamp_ms
+     */
+    time_series::Timestamp get_robot_timestamp_ms(const time_series::Index &t_camera) const
+    {
+        auto t_robot = find_matching_robot_timeindex(t_camera);
+        return robot_frontend_.get_timestamp_ms(t_robot);
+    }
+
+    /**
+     * @brief Get timestamp (in milliseconds) of camera time step t_camera.
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_timestamp_ms
+     */
+    time_series::Timestamp get_camera_timestamp_ms(const time_series::Index &t_camera) const
+    {
+        return camera_frontend_.get_timestamp_ms(t_camera);
+    }
+
+    /**
+     * @brief Get the current camera time index.
+     */
+    time_series::Index get_current_timeindex() const
+    {
+        return camera_frontend_.get_current_timeindex();
+    }
+
+    /**
+     * @brief Wait until camera time step t_camera.
+     */
+    void wait_until_timeindex(const time_series::Index &t_camera) const
+    {
+        camera_frontend_.wait_until_timeindex(t);
+    }
+
+    /**
+     * @brief Get camera images of time step t_camera.
+     *
+     * @param t_camera  Time index of the camera time series.
+     *
+     * @return Camera images of time step t_camera.
+     */
+    CameraObservation get_camera_observation(const time_series::Index t_camera) const
+    {
+        return camera_frontend_.get_observation(t_camera);
+    }
+
+private:
+    robot_interfaces::TriFingerTypes::Frontend robot_frontend_;
+    robot_interfaces::SensorFrontend<CameraObservation> camera_frontend_;
+
+    /**
+     * FIXME: revise this documentation
+     *
+     * @brief Find time index of frontend that matches with the given robot time
+     *        index.
+     *
+     * The given time index t_robot refers to the robot data time series.  To
+     * provide the correct observation from the other frontend for this time
+     * step, find the highest time index t_other of the other frontend where
+     *
+     *      timestamp(t_other) <= timestamp(t_robot)
+     *
+     * Note that this is not always the one that is closest w.r.t. to the
+     * timestamp, i.e.
+     *
+     *      t_other != argmin(|timestamp(t_other) - timestamp(t_robot)|)
+     *
+     * The latter would not be deterministic: the outcome could change when
+     * called twice with the same `t_robot` if a new "other" observation
+     * arrived in between the calls.
+     *
+     * @todo The implementation below is very naive.
+     *       It simply does a linear search starting from the latest time index.
+     *       So worst case performance is O(n) where n is the number of "other"
+     *       observations over the period that is covered by the buffer of the
+     *       robot data.
+     *
+     *       Options to speed this up:
+     *        - binary search (?)
+     *        - estimate time step size based on last observations
+     *        - store matched indices of last call
+     *
+     *       Note, however, that `t_robot` is very likely the latest time index
+     *       in most cases.  In this case the match for `t_other` will also be
+     *       the latest index of the corresponding time series.  In this case,
+     *       the complexity is O(1).  So even when implementing a more complex
+     *       search algorithm, the first candidate for `t_other` that is checked
+     *       should always be the latest one.
+     *
+     * @tparam FrontendType Type of the frontend.  This is templated so that the
+     *     same implementation can be used for both camera and object tracker
+     *     frontend.
+     * @param other_frontend The frontend for which a matching time index needs
+     *     to be found.
+     * @param t_robot Time index of the robot frontend.
+     *
+     * @return Time index for other_frontend which is/was active at the time of
+     *     t_robot.
+     */
+    template <typename FrontendType>
+    time_series::Index find_matching_robot_timeindex(
+        const FrontendType &other_frontend,
+        const time_series::Index t_robot) const
+    {
+        time_series::Timestamp stamp_robot = get_timestamp_ms(t_robot);
+
+        time_series::Index t_other = other_frontend.get_current_timeindex();
+        time_series::Timestamp stamp_other =
+            other_frontend.get_timestamp_ms(t_other);
+
+        while (stamp_robot < stamp_other)
+        {
+            t_other--;
+            stamp_other = other_frontend.get_timestamp_ms(t_other);
+        }
+
+        return t_other;
+    }
+};
+
+
+
 }  // namespace robot_fingers

--- a/include/robot_fingers/trifinger_platform_frontend.hpp
+++ b/include/robot_fingers/trifinger_platform_frontend.hpp
@@ -336,10 +336,11 @@ public:
      * @brief Append a desired robot action to the action queue.
      * @see robot_interfaces::TriFingerTypes::Frontend::append_desired_action
      *
-     * Different to robot_interfaces::TriFingerTypes::Frontend::append_desired_action,
-     * this method does not return a time index.  This is because it is not so easy to
-     * determine the _camera_ time step in which this action will be applied (or if it
-     * even aligns with a specific camera step).
+     * Different to
+     * robot_interfaces::TriFingerTypes::Frontend::append_desired_action, this
+     * method does not return a time index.  This is because it is not so easy
+     * to determine the _camera_ time step in which this action will be applied
+     * (or if it even aligns with a specific camera step).
      */
     void append_desired_action(const Action &desired_action)
     {
@@ -387,16 +388,6 @@ public:
     {
         auto t_robot = find_matching_robot_timeindex(t_camera);
         return robot_frontend_.get_status(t_robot);
-    }
-
-    /**
-     * @brief Deprecated, use @ref get_robot_timestamp_ms instead.
-     */
-    [[deprecated(
-        "Replaced by get_robot_timestamp_ms()")]] time_series::Timestamp
-    get_timestamp_ms(const time_series::Index &t) const
-    {
-        return get_robot_timestamp_ms(t);
     }
 
     /**

--- a/include/robot_fingers/trifinger_platform_frontend.hpp
+++ b/include/robot_fingers/trifinger_platform_frontend.hpp
@@ -336,13 +336,14 @@ public:
      * @brief Append a desired robot action to the action queue.
      * @see robot_interfaces::TriFingerTypes::Frontend::append_desired_action
      *
-     * @return The index of the time step at which this action is going to be
-     *     executed.
+     * Different to robot_interfaces::TriFingerTypes::Frontend::append_desired_action,
+     * this method does not return a time index.  This is because it is not so easy to
+     * determine the _camera_ time step in which this action will be applied (or if it
+     * even aligns with a specific camera step).
      */
-    time_series::Index append_desired_action(const Action &desired_action)
+    void append_desired_action(const Action &desired_action)
     {
-        // FIXME what should this function return?
-        return robot_frontend_.append_desired_action(desired_action);
+        robot_frontend_.append_desired_action(desired_action);
     }
 
     /**

--- a/include/robot_fingers/trifinger_platform_frontend.hpp
+++ b/include/robot_fingers/trifinger_platform_frontend.hpp
@@ -6,6 +6,8 @@
  */
 #pragma once
 
+#include <stdexcept>
+
 #include <robot_interfaces/finger_types.hpp>
 #include <robot_interfaces/sensors/sensor_frontend.hpp>
 #include <trifinger_cameras/tricamera_observation.hpp>
@@ -281,7 +283,7 @@ public:
      *     tracker frontend.
      * @param camera_data SensorData instance, used by the camera frontend.
      */
-    T_TriFingerPlatformFrontend(
+    T_TriFingerPlatformFrontendCameraSynced(
         robot_interfaces::TriFingerTypes::BaseDataPtr robot_data,
         std::shared_ptr<robot_interfaces::SensorData<CameraObservation>>
             camera_data)
@@ -296,7 +298,7 @@ public:
      * instance with the default shared memory ID for the corresponding data
      * type.
      */
-    T_TriFingerPlatformFrontend()
+    T_TriFingerPlatformFrontendCameraSynced()
         : robot_frontend_(std::make_shared<
                           robot_interfaces::TriFingerTypes::MultiProcessData>(
               "trifinger", false)),
@@ -393,7 +395,9 @@ public:
      */
     void wait_until_timeindex(const time_series::Index &t_camera) const
     {
-        camera_frontend_.wait_until_timeindex(t);
+        // sensor frontend doesn't have a dedicated "wait"-method, so use
+        // get_timestamp_ms instead
+        camera_frontend_.get_timestamp_ms(t_camera);
     }
 
     /**
@@ -413,72 +417,64 @@ private:
     robot_interfaces::SensorFrontend<CameraObservation> camera_frontend_;
 
     /**
-     * FIXME: revise this documentation
+     * @brief Find robot time index matching camera time step t_camera.
      *
-     * @brief Find time index of frontend that matches with the given robot time
-     *        index.
-     *
-     * The given time index t_robot refers to the robot data time series.  To
-     * provide the correct observation from the other frontend for this time
-     * step, find the highest time index t_other of the other frontend where
-     *
-     *      timestamp(t_other) <= timestamp(t_robot)
-     *
-     * Note that this is not always the one that is closest w.r.t. to the
-     * timestamp, i.e.
-     *
-     *      t_other != argmin(|timestamp(t_other) - timestamp(t_robot)|)
-     *
-     * The latter would not be deterministic: the outcome could change when
-     * called twice with the same `t_robot` if a new "other" observation
-     * arrived in between the calls.
-     *
-     * @todo The implementation below is very naive.
-     *       It simply does a linear search starting from the latest time index.
-     *       So worst case performance is O(n) where n is the number of "other"
-     *       observations over the period that is covered by the buffer of the
-     *       robot data.
-     *
-     *       Options to speed this up:
-     *        - binary search (?)
-     *        - estimate time step size based on last observations
-     *        - store matched indices of last call
-     *
-     *       Note, however, that `t_robot` is very likely the latest time index
-     *       in most cases.  In this case the match for `t_other` will also be
-     *       the latest index of the corresponding time series.  In this case,
-     *       the complexity is O(1).  So even when implementing a more complex
-     *       search algorithm, the first candidate for `t_other` that is checked
-     *       should always be the latest one.
-     *
-     * @tparam FrontendType Type of the frontend.  This is templated so that the
-     *     same implementation can be used for both camera and object tracker
-     *     frontend.
-     * @param other_frontend The frontend for which a matching time index needs
-     *     to be found.
-     * @param t_robot Time index of the robot frontend.
-     *
-     * @return Time index for other_frontend which is/was active at the time of
-     *     t_robot.
+     * Uses the average timestamp of the three camera images in the given camera
+     * observation and finds the robot time index whose observation timestamp is
+     * closest to it.
      */
-    template <typename FrontendType>
     time_series::Index find_matching_robot_timeindex(
-        const FrontendType &other_frontend,
-        const time_series::Index t_robot) const
+        const time_series::Index t_camera) const
     {
-        time_series::Timestamp stamp_robot = get_timestamp_ms(t_robot);
+        const CameraObservation camera_observation =
+            camera_frontend_.get_observation(t_camera);
+        const time_series::Timestamp timestamp_images =
+            get_average_image_timestamp_ms(camera_observation);
 
-        time_series::Index t_other = other_frontend.get_current_timeindex();
-        time_series::Timestamp stamp_other =
-            other_frontend.get_timestamp_ms(t_other);
+        time_series::Index t_robot = robot_frontend_.get_current_timeindex();
+        time_series::Timestamp timestamp_robot =
+            robot_frontend_.get_timestamp_ms(t_robot);
 
-        while (stamp_robot < stamp_other)
+        if (timestamp_robot <= timestamp_images)
         {
-            t_other--;
-            stamp_other = other_frontend.get_timestamp_ms(t_other);
+            return t_robot;
         }
 
-        return t_other;
+        time_series::Index t_next = t_robot;
+        time_series::Timestamp timestamp_next = timestamp_robot;
+
+        while (timestamp_robot > timestamp_images)
+        {
+            t_next = t_robot;
+            timestamp_next = timestamp_robot;
+
+            t_robot--;
+            try
+            {
+                timestamp_robot = robot_frontend_.get_timestamp_ms(t_robot);
+            }
+            catch (const std::invalid_argument &)
+            {
+                return t_next;
+            }
+        }
+
+        const time_series::Timestamp diff_prev = timestamp_images - timestamp_robot;
+        const time_series::Timestamp diff_next = timestamp_next - timestamp_images;
+        return (diff_prev <= diff_next) ? t_robot : t_next;
+    }
+
+    time_series::Timestamp get_average_image_timestamp_ms(
+        const CameraObservation &camera_observation) const
+    {
+        // FIXME double-check that camera timestamps are in ms
+        time_series::Timestamp sum = 0;
+        for (const auto &camera : camera_observation.cameras)
+        {
+            sum += static_cast<time_series::Timestamp>(camera.timestamp);
+        }
+        return sum / static_cast<time_series::Timestamp>(
+                          camera_observation.cameras.size());
     }
 };
 

--- a/include/robot_fingers/trifinger_platform_frontend.hpp
+++ b/include/robot_fingers/trifinger_platform_frontend.hpp
@@ -508,14 +508,17 @@ private:
     time_series::Timestamp get_average_image_timestamp_ms(
         const CameraObservation &camera_observation) const
     {
-        // FIXME double-check that camera timestamps are in ms
-        time_series::Timestamp sum = 0;
+        double sum_sec = 0;
         for (const auto &camera : camera_observation.cameras)
         {
-            sum += static_cast<time_series::Timestamp>(camera.timestamp);
+            sum_sec += static_cast<time_series::Timestamp>(camera.timestamp);
         }
-        return sum / static_cast<time_series::Timestamp>(
-                         camera_observation.cameras.size());
+
+        // camera timestamps are in seconds, so convert to ms here
+        double sum_ms = sum_sec * 1000;
+
+        return static_cast<time_series::Timestamp>(
+            sum_ms / camera_observation.cameras.size());
     }
 };
 

--- a/include/robot_fingers/trifinger_platform_frontend.hpp
+++ b/include/robot_fingers/trifinger_platform_frontend.hpp
@@ -26,8 +26,6 @@ namespace robot_fingers
  * one that belongs to the robot frontend.  When accessing observations of the
  * other frontends, it also takes this index t and internally matches it to the
  * time index t_o that was active in the other frontend at the time of t.
- *
- * @todo Methods to get timestamp from camera or object tracker?
  */
 template <typename CameraObservation_t>
 class T_TriFingerPlatformFrontend
@@ -125,12 +123,37 @@ public:
     }
 
     /**
+     * @brief Deprecated, use @ref get_robot_timestamp_ms instead.
+     */
+    [[deprecated(
+        "Replaced by get_robot_timestamp_ms()")]] time_series::Timestamp
+    get_timestamp_ms(const time_series::Index &t) const
+    {
+        return get_robot_timestamp_ms(t);
+    }
+
+    /**
      * @brief Get timestamp (in milliseconds) of time step t.
      * @see robot_interfaces::TriFingerTypes::Frontend::get_timestamp_ms
      */
-    time_series::Timestamp get_timestamp_ms(const time_series::Index &t) const
+    time_series::Timestamp get_robot_timestamp_ms(
+        const time_series::Index &t) const
     {
         return robot_frontend_.get_timestamp_ms(t);
+    }
+
+    /**
+     * @brief Get timestamp (in milliseconds) of the camera observation at time
+     * step t.
+     *
+     * @param t  Time index of the robot time series.  This is internally
+     *      mapped to the corresponding time index of the camera time series.
+     */
+    time_series::Timestamp get_camera_timestamp_ms(
+        const time_series::Index &t) const
+    {
+        auto t_camera = find_matching_timeindex(camera_frontend_, t);
+        return camera_frontend_.get_timestamp_ms(t_camera);
     }
 
     /**
@@ -253,15 +276,14 @@ typedef T_TriFingerPlatformFrontend<trifinger_cameras::TriCameraObservation>
  * This class combines the frontends for robot and cameras in one class using
  * unified time indices.
  *
- * It is similar to @ref T_TriFingerPlatformFrontend but uses the camera time steps as
- * base for accessing observations.
+ * It is similar to @ref T_TriFingerPlatformFrontend but uses the camera time
+ * steps as base for accessing observations.
  *
- * So methods for accessing robot observations/actions/status take as input a camera
- * time step t_c and internally map it to the robot time step t_r which is closest to
- * the moment when the images where fetched from the cameras (i.e. it uses the _image
- * timestamps_ for synchronizing, not the timestamp of the _camera observation_).
- *
- * @todo Methods to get timestamp from camera or object tracker?
+ * So methods for accessing robot observations/actions/status take as input a
+ * camera time step t_c and internally map it to the robot time step t_r which
+ * is closest to the moment when the images where fetched from the cameras (i.e.
+ * it uses the _image timestamps_ for synchronizing, not the timestamp of the
+ * _camera observation_).
  */
 template <typename CameraObservation_t>
 class T_TriFingerPlatformFrontendCameraSynced
@@ -324,10 +346,12 @@ public:
     }
 
     /**
-     * @brief Get robot observation matching images in camera time step t_camera.
+     * @brief Get robot observation matching images in camera time step
+     * t_camera.
      * @see robot_interfaces::TriFingerTypes::Frontend::get_observation
      */
-    RobotObservation get_robot_observation(const time_series::Index &t_camera) const
+    RobotObservation get_robot_observation(
+        const time_series::Index &t_camera) const
     {
         auto t_robot = find_matching_robot_timeindex(t_camera);
         return robot_frontend_.get_observation(t_robot);
@@ -344,7 +368,8 @@ public:
     }
 
     /**
-     * @brief Get actually applied action matching images in camera time step t_camera.
+     * @brief Get actually applied action matching images in camera time step
+     * t_camera.
      * @see robot_interfaces::TriFingerTypes::Frontend::get_applied_action
      */
     Action get_applied_action(const time_series::Index &t_camera) const
@@ -364,10 +389,22 @@ public:
     }
 
     /**
-     * @brief Get timestamp (in milliseconds) matching images in camera time step t_camera.
+     * @brief Deprecated, use @ref get_robot_timestamp_ms instead.
+     */
+    [[deprecated(
+        "Replaced by get_robot_timestamp_ms()")]] time_series::Timestamp
+    get_timestamp_ms(const time_series::Index &t) const
+    {
+        return get_robot_timestamp_ms(t);
+    }
+
+    /**
+     * @brief Get timestamp (in milliseconds) matching images in camera time
+     * step t_camera.
      * @see robot_interfaces::TriFingerTypes::Frontend::get_timestamp_ms
      */
-    time_series::Timestamp get_robot_timestamp_ms(const time_series::Index &t_camera) const
+    time_series::Timestamp get_robot_timestamp_ms(
+        const time_series::Index &t_camera) const
     {
         auto t_robot = find_matching_robot_timeindex(t_camera);
         return robot_frontend_.get_timestamp_ms(t_robot);
@@ -377,7 +414,8 @@ public:
      * @brief Get timestamp (in milliseconds) of camera time step t_camera.
      * @see robot_interfaces::TriFingerTypes::Frontend::get_timestamp_ms
      */
-    time_series::Timestamp get_camera_timestamp_ms(const time_series::Index &t_camera) const
+    time_series::Timestamp get_camera_timestamp_ms(
+        const time_series::Index &t_camera) const
     {
         return camera_frontend_.get_timestamp_ms(t_camera);
     }
@@ -407,7 +445,8 @@ public:
      *
      * @return Camera images of time step t_camera.
      */
-    CameraObservation get_camera_observation(const time_series::Index t_camera) const
+    CameraObservation get_camera_observation(
+        const time_series::Index t_camera) const
     {
         return camera_frontend_.get_observation(t_camera);
     }
@@ -459,8 +498,10 @@ private:
             }
         }
 
-        const time_series::Timestamp diff_prev = timestamp_images - timestamp_robot;
-        const time_series::Timestamp diff_next = timestamp_next - timestamp_images;
+        const time_series::Timestamp diff_prev =
+            timestamp_images - timestamp_robot;
+        const time_series::Timestamp diff_next =
+            timestamp_next - timestamp_images;
         return (diff_prev <= diff_next) ? t_robot : t_next;
     }
 
@@ -474,10 +515,15 @@ private:
             sum += static_cast<time_series::Timestamp>(camera.timestamp);
         }
         return sum / static_cast<time_series::Timestamp>(
-                          camera_observation.cameras.size());
+                         camera_observation.cameras.size());
     }
 };
 
-
+typedef T_TriFingerPlatformFrontendCameraSynced<
+    trifinger_object_tracking::TriCameraObjectObservation>
+    TriFingerPlatformWithObjectFrontendCameraSynced;
+typedef T_TriFingerPlatformFrontendCameraSynced<
+    trifinger_cameras::TriCameraObservation>
+    TriFingerPlatformFrontendCameraSynced;
 
 }  // namespace robot_fingers

--- a/robot_fingers/__init__.py
+++ b/robot_fingers/__init__.py
@@ -10,6 +10,8 @@ from .py_trifinger import (
     TriFingerConfig,
     TriFingerPlatformFrontend,
     TriFingerPlatformWithObjectFrontend,
+    TriFingerPlatformFrontendCameraSynced,
+    TriFingerPlatformWithObjectFrontendCameraSynced,
     TriFingerPlatformLog,
     TriFingerPlatformWithObjectLog,
 )
@@ -28,6 +30,8 @@ __all__ = (
     "TriFingerConfig",
     "TriFingerPlatformFrontend",
     "TriFingerPlatformWithObjectFrontend",
+    "TriFingerPlatformFrontendCameraSynced",
+    "TriFingerPlatformWithObjectFrontendCameraSynced",
     "TriFingerPlatformLog",
     "TriFingerPlatformWithObjectLog",
     "create_one_joint_backend",

--- a/srcpy/py_trifinger.cpp
+++ b/srcpy/py_trifinger.cpp
@@ -139,13 +139,43 @@ void pybind_trifinger_platform_frontend(pybind11::module &m,
 
                 If t is in the future, this method will block and wait.
 )XXX")
-        .def("get_timestamp_ms",
-             &T::get_timestamp_ms,
+        .def(
+            "get_timestamp_ms",
+            [](pybind11::object &self, int t)
+            {
+                auto warnings = pybind11::module::import("warnings");
+                auto builtins = pybind11::module::import("builtins");
+                warnings.attr("warn")(
+                    "get_timestamp_ms() is deprecated, use "
+                    "get_robot_timestamp_ms() instead.",
+                    builtins.attr("FutureWarning"));
+
+                return self.attr("get_robot_timestamp_ms")(t);
+            },
+            R"XXX(
+                get_timestamp_ms(t: int) -> float
+
+                Deprecated, use get_robot_timestamp_ms() instead, which behaves the
+                same.
+)XXX")
+        .def("get_robot_timestamp_ms",
+             &T::get_robot_timestamp_ms,
              pybind11::call_guard<pybind11::gil_scoped_release>(),
              R"XXX(
                 get_timestamp_ms(t: int) -> float
 
                 Get timestamp in milliseconds of time step t.
+
+                If t is in the future, this method will block and wait.
+)XXX")
+        .def("get_camera_timestamp_ms",
+             &T::get_camera_timestamp_ms,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                get_camera_timestamp_ms(t: int) -> float
+
+                Get timestamp of the camera observation of time step t (in
+                milliseconds).
 
                 If t is in the future, this method will block and wait.
 )XXX")
@@ -292,6 +322,14 @@ PYBIND11_MODULE(py_trifinger, m)
         m, "TriFingerPlatformFrontend");
     pybind_trifinger_platform_frontend<TriFingerPlatformWithObjectFrontend>(
         m, "TriFingerPlatformWithObjectFrontend");
+
+    // FIXME using pybind_trifinger_platform_frontend here will likely result in
+    // wrong docstrings
+    pybind_trifinger_platform_frontend<TriFingerPlatformFrontendCameraSynced>(
+        m, "TriFingerPlatformFrontendCameraSynced");
+    pybind_trifinger_platform_frontend<
+        TriFingerPlatformWithObjectFrontendCameraSynced>(
+        m, "TriFingerPlatformWithObjectFrontendCameraSynced");
 
     pybind_trifinger_platform_log<TriFingerPlatformLog>(m,
                                                         "TriFingerPlatformLog");

--- a/srcpy/py_trifinger.cpp
+++ b/srcpy/py_trifinger.cpp
@@ -198,6 +198,159 @@ void pybind_trifinger_platform_frontend(pybind11::module &m,
 }
 
 template <typename T>
+void pybind_trifinger_platform_frontend_camera_synced(pybind11::module &m,
+                                                      const std::string &name)
+{
+    auto trifinger_types =
+        pybind11::module::import("robot_interfaces.py_trifinger_types");
+
+    pybind11::class_<T, std::shared_ptr<T>> PyT(m, name.c_str());
+
+    // expose the "Action" typedef to Python
+    PyT.attr("Action") = trifinger_types.attr("Action");
+
+    PyT.def(pybind11::init<>())
+        .def("append_desired_action",
+             &T::append_desired_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             "desired_action"_a,
+             R"XXX(
+             append_desired_action(action: robot_interfaces.trifinger.Action)
+
+             Append a desired action to the action time series.
+
+             Append an action to the "desired actions" time series.
+             Note that this does *not* block until the action is actually
+             executed. The time series acts like a queue from which the
+             actions are taken one by one to send them to the actual robot.
+             It is possible to call this method multiple times in a row to
+             already provide actions for the next time steps.
+
+             Args:
+                 desired_action:  The action that shall be applied on the
+                     robot.  Note that the actually applied action might be
+                     different (see :meth:`get_applied_action`).
+)XXX")
+        .def("get_robot_observation",
+             &T::get_robot_observation,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                get_robot_observation(t_camera: int) -> robot_interfaces.trifinger.Observation
+
+                Get robot observation matching images in camera time step t_camera.
+
+                If t_camera is in the future, this method will block and wait.
+
+                Args:
+                    t_camera: Index of the time step.
+
+                Returns:
+                    Robot observation of time step t_camera.
+
+                Raises:
+                    Exception: if t_camera is too old and not in the time series buffer
+                        anymore.
+)XXX")
+        .def("get_camera_observation",
+             &T::get_camera_observation,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                get_camera_observation(t_camera: int)
+
+                Get camera images of time step t_camera.
+
+                If t_camera is in the future, this method will block and wait.
+
+                Args:
+                    t_camera:  Time index of the camera time series.
+
+                Returns:
+                    Camera images of time step t_camera.
+
+                Raises:
+                    Exception: if t_camera is too old and not in the time series buffer
+                        anymore.
+)XXX")
+        .def("get_desired_action",
+             &T::get_desired_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                get_desired_action(t_camera: int) -> robot_interfaces.trifinger.Action
+
+                Get desired action matching images in camera time step t_camera.
+
+                This corresponds to the action that was appended using
+                `append_desired_action()`.  Note that the actually applied
+                action may differ, see `get_applied_action()`.
+
+                If t_camera is in the future, this method will block and wait.
+)XXX")
+        .def("get_applied_action",
+             &T::get_applied_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                get_applied_action(t_camera: int) -> robot_interfaces.trifinger.Action
+
+                Get actually applied action matching images in camera time step
+                t_camera.
+
+                The applied action is the one that was actually applied to the
+                robot based on the desired action of that time step.  It may
+                differ from the desired one e.g. due to safety checks which
+                limit the maximum torque and enforce the position limits.
+
+                If t_camera is in the future, this method will block and wait.
+)XXX")
+        .def("get_robot_status",
+             &T::get_robot_status,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                get_robot_status(t_camera: int) -> robot_interfaces.Status
+
+                Get robot status matching images in camera time step t_camera.
+
+                If t_camera is in the future, this method will block and wait.
+)XXX")
+        .def("get_robot_timestamp_ms",
+             &T::get_robot_timestamp_ms,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                get_robot_timestamp_ms(t_camera: int) -> float
+
+                Get timestamp in milliseconds matching images in camera time step
+                t_camera.
+
+                If t_camera is in the future, this method will block and wait.
+)XXX")
+        .def("get_camera_timestamp_ms",
+             &T::get_camera_timestamp_ms,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                get_camera_timestamp_ms(t_camera: int) -> float
+
+                Get timestamp of camera time step t_camera (in milliseconds).
+
+                If t_camera is in the future, this method will block and wait.
+)XXX")
+        .def("wait_until_timeindex",
+             &T::wait_until_timeindex,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                wait_until_timeindex(t_camera: int)
+
+                Wait until camera time step t_camera is reached.
+)XXX")
+        .def("get_current_timeindex",
+             &T::get_current_timeindex,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                get_current_timeindex() -> int
+
+                Get the current camera time index.
+)XXX");
+}
+
+template <typename T>
 void pybind_trifinger_platform_log(pybind11::module &m, const std::string &name)
 {
     pybind11::class_<T, std::shared_ptr<T>>(m,
@@ -323,11 +476,10 @@ PYBIND11_MODULE(py_trifinger, m)
     pybind_trifinger_platform_frontend<TriFingerPlatformWithObjectFrontend>(
         m, "TriFingerPlatformWithObjectFrontend");
 
-    // FIXME using pybind_trifinger_platform_frontend here will likely result in
-    // wrong docstrings
-    pybind_trifinger_platform_frontend<TriFingerPlatformFrontendCameraSynced>(
+    pybind_trifinger_platform_frontend_camera_synced<
+        TriFingerPlatformFrontendCameraSynced>(
         m, "TriFingerPlatformFrontendCameraSynced");
-    pybind_trifinger_platform_frontend<
+    pybind_trifinger_platform_frontend_camera_synced<
         TriFingerPlatformWithObjectFrontendCameraSynced>(
         m, "TriFingerPlatformWithObjectFrontendCameraSynced");
 

--- a/test/test_trifinger_platform_frontend_camera_synced.cpp
+++ b/test/test_trifinger_platform_frontend_camera_synced.cpp
@@ -1,0 +1,63 @@
+#include <gtest/gtest.h>
+
+#include <real_time_tools/timer.hpp>
+#include <robot_fingers/trifinger_platform_frontend.hpp>
+#include <robot_interfaces/sensors/sensor_data.hpp>
+
+namespace
+{
+using CameraObservation = trifinger_cameras::TriCameraObservation;
+using Action = robot_interfaces::TriFingerTypes::Action;
+using Observation = robot_interfaces::TriFingerTypes::Observation;
+using Frontend =
+    robot_fingers::T_TriFingerPlatformFrontendCameraSynced<CameraObservation>;
+
+Observation make_observation(double marker)
+{
+    Observation observation;
+    observation.position[0] = marker;
+    return observation;
+}
+
+CameraObservation make_camera_observation(double timestamp_ms)
+{
+    CameraObservation observation;
+    for (auto &camera : observation.cameras)
+    {
+        camera.timestamp = timestamp_ms;
+    }
+    return observation;
+}
+}  // namespace
+
+TEST(TriFingerPlatformFrontendCameraSynced, PicksClosestRobotTimestamp)
+{
+    auto robot_data =
+        std::make_shared<robot_interfaces::TriFingerTypes::SingleProcessData>(
+            10);
+    auto camera_data = std::make_shared<
+        robot_interfaces::SingleProcessSensorData<CameraObservation>>(10);
+
+    Frontend frontend(robot_data, camera_data);
+
+    robot_data->observation->append(make_observation(1.0));
+    real_time_tools::Timer::sleep_ms(2);
+    robot_data->observation->append(make_observation(2.0));
+    real_time_tools::Timer::sleep_ms(2);
+    robot_data->observation->append(make_observation(3.0));
+
+    const auto t1 = robot_data->observation->timestamp_ms(1);
+    const auto t2 = robot_data->observation->timestamp_ms(2);
+
+    const double avg_close_to_t1 = t1 + (t2 - t1) * 0.25;
+    const double avg_close_to_t2 = t1 + (t2 - t1) * 0.75;
+    const double avg_after_t2 = t2 + 1000.0;
+
+    camera_data->observation->append(make_camera_observation(avg_close_to_t1));
+    camera_data->observation->append(make_camera_observation(avg_close_to_t2));
+    camera_data->observation->append(make_camera_observation(avg_after_t2));
+
+    EXPECT_DOUBLE_EQ(frontend.get_robot_observation(0).position[0], 2.0);
+    EXPECT_DOUBLE_EQ(frontend.get_robot_observation(1).position[0], 3.0);
+    EXPECT_DOUBLE_EQ(frontend.get_robot_observation(2).position[0], 3.0);
+}

--- a/test/test_trifinger_platform_frontend_camera_synced.cpp
+++ b/test/test_trifinger_platform_frontend_camera_synced.cpp
@@ -24,7 +24,7 @@ CameraObservation make_camera_observation(double timestamp_ms)
     CameraObservation observation;
     for (auto &camera : observation.cameras)
     {
-        camera.timestamp = timestamp_ms;
+        camera.timestamp = timestamp_ms / 1000;
     }
     return observation;
 }


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

This is a complement to the already existing TriFingerPlatformFrontend.
Instead of providing the latest camera observation for a given robot
time step, it expects as input the camera time steps and finds the robot
observation that is closest to the moment in time when the images of
that observation where fetched from the cameras.
So this new front end class will only provide observations at the rate
of the camera, but it will ensure camera and robot observations provided
for a given time step where recorded more or less simultaneously (i.e.
the robot observation represents the actual robot state that is shown in
the images).


## How I Tested

So far only with simulation backend.