### PR TITLE
doc: Add kinematics demo to examples

### DIFF
--- a/doc/examples/demo_trifingerpro_kinematics.rst
+++ b/doc/examples/demo_trifingerpro_kinematics.rst
@@ -1,0 +1,11 @@
+************************************************
+Example: TriFingerPro Forward/Inverse Kinematics
+************************************************
+
+Demo computing forward and inverse kinematics for the TriFingerPro robot.
+
+.. literalinclude:: /PKG/demos/demo_trifingerpro_kinematics.py
+
+This example is also shipped with the package and can be found in
+``demos/demo_trifingerpro_kinematics.py``.
+

--- a/doc/examples/index.rst
+++ b/doc/examples/index.rst
@@ -11,6 +11,7 @@ Below is a list of some relevant example scripts.  More examples can be found in
    demo_single_finger_position_control.rst
    demo_single_finger_torque_control.rst
    demo_trifinger.rst
+   demo_trifingerpro_kinematics.rst
 
 
 .. _demos: https://github.com/open-dynamic-robot-initiative/robot_fingers/blob/master/demos


### PR DESCRIPTION
## Description

Add `demo_trifingerpro_kinematics.py` in the rendered documentation, so that we can link to it from other parts of the documentation (most specifically in the documentation of robot_properties_fingers)


## How I Tested

Built locally.
