### PR TITLE
Add direct access to robot data in camera-synced frontend

### DIFF
--- a/include/robot_fingers/trifinger_platform_frontend.hpp
+++ b/include/robot_fingers/trifinger_platform_frontend.hpp
@@ -270,10 +270,22 @@ typedef T_TriFingerPlatformFrontend<trifinger_cameras::TriCameraObservation>
 ///////////////////////////////////////////////////////////////
 
 /**
+ * @brief Wrapper around time_series::Index for explicitly representing a
+ * _robot_ time index (as opposed to _camera_ time index).
+ */
+struct RobotTimeIndex
+{
+    time_series::Index value;
+    explicit RobotTimeIndex(int v) : value(v)
+    {
+    }
+};
+
+/**
  * @brief Combined front end for the TriFinger Platform, synchronizing robot
  * observations with the camera.
  *
- * This class combines the frontends for robot and cameras in one class using
+ * This class combines the front ends for robot and cameras in one class using
  * unified time indices.
  *
  * It is similar to @ref T_TriFingerPlatformFrontend but uses the camera time
@@ -284,6 +296,16 @@ typedef T_TriFingerPlatformFrontend<trifinger_cameras::TriCameraObservation>
  * is closest to the moment when the images where fetched from the cameras (i.e.
  * it uses the _image timestamps_ for synchronizing, not the timestamp of the
  * _camera observation_).
+ *
+ * @ref append_desired_action still returns the _robot_ time index when the
+ * action will be applied and getter methods prefixed with "robot_" are provided
+ * to access data of the corresponding steps (e.g. @ref
+ * robot_get_robot_observation, @ref robot_get_robot_timestamp_ms, ...).  Those
+ * may be useful for better analysis, e.g. to check intermediate robot states
+ * or get exact timestamps of robot actions. However, this robot time index
+ * must not be used with the regular getter methods (@ref get_robot_observation,
+ * ...) and is wrapped in a struct @ref RobotTimeIndex to avoid accidental
+ * mix-up.
  */
 template <typename CameraObservation_t>
 class T_TriFingerPlatformFrontendCameraSynced
@@ -336,15 +358,21 @@ public:
      * @brief Append a desired robot action to the action queue.
      * @see robot_interfaces::TriFingerTypes::Frontend::append_desired_action
      *
-     * Different to
-     * robot_interfaces::TriFingerTypes::Frontend::append_desired_action, this
-     * method does not return a time index.  This is because it is not so easy
-     * to determine the _camera_ time step in which this action will be applied
-     * (or if it even aligns with a specific camera step).
+     * **Notice:** The returned time index refers to the robot time series, not
+     * the camera time series.  This is because it is not so easy to determine
+     * the _camera_ time step in which this action will be applied (or if it
+     * even aligns with a specific camera step). The returned value might still
+     * be useful in some situations but it should not (and cannot) be used with
+     * functions like @ref get_robot_observation.
+     *
+     * @return Robot time step when the action will be applied.  See notice
+     * above!
      */
-    void append_desired_action(const Action &desired_action)
+    RobotTimeIndex append_desired_action(const Action &desired_action)
     {
-        robot_frontend_.append_desired_action(desired_action);
+        time_series::Index t =
+            robot_frontend_.append_desired_action(desired_action);
+        return RobotTimeIndex(t);
     }
 
     /**
@@ -441,6 +469,55 @@ public:
         const time_series::Index t_camera) const
     {
         return camera_frontend_.get_observation(t_camera);
+    }
+
+    /**
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_observation
+     */
+    RobotObservation robot_get_robot_observation(RobotTimeIndex t_robot) const
+    {
+        return robot_frontend_.get_observation(t_robot.value);
+    }
+
+    /**
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_desired_action
+     */
+    Action robot_get_desired_action(RobotTimeIndex t_robot) const
+    {
+        return robot_frontend_.get_desired_action(t_robot.value);
+    }
+
+    /**
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_applied_action
+     */
+    Action robot_get_applied_action(RobotTimeIndex t_robot) const
+    {
+        return robot_frontend_.get_applied_action(t_robot.value);
+    }
+
+    /**
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_status
+     */
+    RobotStatus robot_get_robot_status(RobotTimeIndex t_robot) const
+    {
+        return robot_frontend_.get_status(t_robot.value);
+    }
+
+    /**
+     * @see robot_interfaces::TriFingerTypes::Frontend::get_timestamp_ms
+     */
+    time_series::Timestamp robot_get_robot_timestamp_ms(
+        RobotTimeIndex t_robot) const
+    {
+        return robot_frontend_.get_timestamp_ms(t_robot.value);
+    }
+
+    /**
+     * @brief Get the current robot time index.
+     */
+    RobotTimeIndex robot_get_current_timeindex() const
+    {
+        return RobotTimeIndex(robot_frontend_.get_current_timeindex());
     }
 
 private:

--- a/srcpy/py_trifinger.cpp
+++ b/srcpy/py_trifinger.cpp
@@ -215,7 +215,7 @@ void pybind_trifinger_platform_frontend_camera_synced(pybind11::module &m,
              pybind11::call_guard<pybind11::gil_scoped_release>(),
              "desired_action"_a,
              R"XXX(
-             append_desired_action(action: robot_interfaces.trifinger.Action)
+             append_desired_action(action: robot_interfaces.trifinger.Action) -> RobotTimeIndex
 
              Append a desired action to the action time series.
 
@@ -230,6 +230,13 @@ void pybind_trifinger_platform_frontend_camera_synced(pybind11::module &m,
                  desired_action:  The action that shall be applied on the
                      robot.  Note that the actually applied action might be
                      different (see :meth:`get_applied_action`).
+
+             Returns:
+                 Robot time step at wich the action will be applied.
+                 **Important:** The regular getter methods of this class (e.g.
+                 :meth:`get_robot_observation`) are expecting the *camera* time
+                 steps.  Do not call them with the *robot* time step!  The robot
+                 time step may be used with the "robot_" getter methods (e.g. :meth:`robot_get_robot_observation`) for analysis purposes.
 )XXX")
         .def("get_robot_observation",
              &T::get_robot_observation,
@@ -347,6 +354,60 @@ void pybind_trifinger_platform_frontend_camera_synced(pybind11::module &m,
                 get_current_timeindex() -> int
 
                 Get the current camera time index.
+)XXX")
+        .def("robot_get_robot_observation",
+             &T::robot_get_robot_observation,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                robot_get_robot_observation(t_robot: RobotTimeIndex) -> robot_interfaces.trifinger.Observation
+
+                Get robot observation of robot time step t_robot.
+
+                If t_robot is in the future, this method will block and wait.
+
+                Raises:
+                    Exception: if t_robot is too old and not in the time series buffer
+                        anymore.
+)XXX")
+        .def("robot_get_desired_action",
+             &T::robot_get_desired_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                robot_get_desired_action(t_robot: RobotTimeIndex) -> robot_interfaces.trifinger.Action
+
+                Get desired action of robot time step t_robot.
+)XXX")
+        .def("robot_get_applied_action",
+             &T::robot_get_applied_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                robot_get_applied_action(t_robot: RobotTimeIndex) -> robot_interfaces.trifinger.Action
+
+                Get actually applied action of robot time step t_robot.
+)XXX")
+        .def("robot_get_robot_status",
+             &T::robot_get_robot_status,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                robot_get_robot_status(t_robot: RobotTimeIndex) -> robot_interfaces.Status
+
+                Get robot status of robot time step t_robot.
+)XXX")
+        .def("robot_get_robot_timestamp_ms",
+             &T::robot_get_robot_timestamp_ms,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                robot_get_robot_timestamp_ms(t_robot: RobotTimeIndex) -> float
+
+                Get timestamp in milliseconds of robot time step t_robot.
+)XXX")
+        .def("robot_get_current_timeindex",
+             &T::robot_get_current_timeindex,
+             pybind11::call_guard<pybind11::gil_scoped_release>(),
+             R"XXX(
+                robot_get_current_timeindex() -> RobotTimeIndex
+
+                Get the current robot time index.
 )XXX");
 }
 
@@ -476,6 +537,14 @@ PYBIND11_MODULE(py_trifinger, m)
     pybind_trifinger_platform_frontend<TriFingerPlatformWithObjectFrontend>(
         m, "TriFingerPlatformWithObjectFrontend");
 
+    pybind11::class_<RobotTimeIndex, std::shared_ptr<RobotTimeIndex>>(
+        m, "RobotTimeIndex")
+        .def(pybind11::init<int>(), "value"_a)
+        .def_readonly("value", &RobotTimeIndex::value)
+        .def("__repr__",
+             [](const RobotTimeIndex &index)
+             { return "RobotTimeIndex(" + std::to_string(index.value) + ")"; });
+    ;
     pybind_trifinger_platform_frontend_camera_synced<
         TriFingerPlatformFrontendCameraSynced>(
         m, "TriFingerPlatformFrontendCameraSynced");

--- a/test/test_trifinger_platform_frontend_camera_synced.cpp
+++ b/test/test_trifinger_platform_frontend_camera_synced.cpp
@@ -41,11 +41,11 @@ TEST(TriFingerPlatformFrontendCameraSynced, PicksClosestRobotTimestamp)
 
     Frontend frontend(robot_data, camera_data);
 
+    robot_data->observation->append(make_observation(0.0));
+    real_time_tools::Timer::sleep_ms(2);
     robot_data->observation->append(make_observation(1.0));
     real_time_tools::Timer::sleep_ms(2);
     robot_data->observation->append(make_observation(2.0));
-    real_time_tools::Timer::sleep_ms(2);
-    robot_data->observation->append(make_observation(3.0));
 
     const auto t1 = robot_data->observation->timestamp_ms(1);
     const auto t2 = robot_data->observation->timestamp_ms(2);
@@ -58,20 +58,20 @@ TEST(TriFingerPlatformFrontendCameraSynced, PicksClosestRobotTimestamp)
     camera_data->observation->append(make_camera_observation(avg_close_to_t2));
     camera_data->observation->append(make_camera_observation(avg_after_t2));
 
-    EXPECT_DOUBLE_EQ(frontend.get_robot_observation(0).position[0], 2.0);
-    EXPECT_DOUBLE_EQ(frontend.get_robot_observation(1).position[0], 3.0);
-    EXPECT_DOUBLE_EQ(frontend.get_robot_observation(2).position[0], 3.0);
+    EXPECT_DOUBLE_EQ(frontend.get_robot_observation(0).position[0], 1.0);
+    EXPECT_DOUBLE_EQ(frontend.get_robot_observation(1).position[0], 2.0);
+    EXPECT_DOUBLE_EQ(frontend.get_robot_observation(2).position[0], 2.0);
 
     // also test direct access to robot observations
     EXPECT_DOUBLE_EQ(
         frontend.robot_get_robot_observation(RobotTimeIndex(0)).position[0],
-        1.0);
+        0.0);
     EXPECT_DOUBLE_EQ(
         frontend.robot_get_robot_observation(RobotTimeIndex(1)).position[0],
-        2.0);
+        1.0);
     EXPECT_DOUBLE_EQ(
         frontend.robot_get_robot_observation(RobotTimeIndex(2)).position[0],
-        3.0);
+        2.0);
 
     // check timestamps
     EXPECT_DOUBLE_EQ(frontend.get_robot_timestamp_ms(0), t1);

--- a/test/test_trifinger_platform_frontend_camera_synced.cpp
+++ b/test/test_trifinger_platform_frontend_camera_synced.cpp
@@ -11,6 +11,7 @@ using Action = robot_interfaces::TriFingerTypes::Action;
 using Observation = robot_interfaces::TriFingerTypes::Observation;
 using Frontend =
     robot_fingers::T_TriFingerPlatformFrontendCameraSynced<CameraObservation>;
+using RobotTimeIndex = robot_fingers::RobotTimeIndex;
 
 Observation make_observation(double marker)
 {
@@ -60,4 +61,25 @@ TEST(TriFingerPlatformFrontendCameraSynced, PicksClosestRobotTimestamp)
     EXPECT_DOUBLE_EQ(frontend.get_robot_observation(0).position[0], 2.0);
     EXPECT_DOUBLE_EQ(frontend.get_robot_observation(1).position[0], 3.0);
     EXPECT_DOUBLE_EQ(frontend.get_robot_observation(2).position[0], 3.0);
+
+    // also test direct access to robot observations
+    EXPECT_DOUBLE_EQ(
+        frontend.robot_get_robot_observation(RobotTimeIndex(0)).position[0],
+        1.0);
+    EXPECT_DOUBLE_EQ(
+        frontend.robot_get_robot_observation(RobotTimeIndex(1)).position[0],
+        2.0);
+    EXPECT_DOUBLE_EQ(
+        frontend.robot_get_robot_observation(RobotTimeIndex(2)).position[0],
+        3.0);
+
+    // check timestamps
+    EXPECT_DOUBLE_EQ(frontend.get_robot_timestamp_ms(0), t1);
+    EXPECT_DOUBLE_EQ(frontend.get_robot_timestamp_ms(1), t2);
+    EXPECT_DOUBLE_EQ(frontend.get_robot_timestamp_ms(2), t2);
+    EXPECT_NE(frontend.robot_get_robot_timestamp_ms(RobotTimeIndex(0)), t1);
+    EXPECT_DOUBLE_EQ(frontend.robot_get_robot_timestamp_ms(RobotTimeIndex(1)),
+                     t1);
+    EXPECT_DOUBLE_EQ(frontend.robot_get_robot_timestamp_ms(RobotTimeIndex(2)),
+                     t2);
 }


### PR DESCRIPTION
## Description

For debugging and analysis purposes, it can be useful to still be able
to directly access the robot time series data in the
TriFingerPlatformFrontendCameraSynced.
There for this commit changes `append_desired_action` to return a
(wrapped) robot time index and adds methods for directly accessing robot
observations, actions, etc. using this time index (all prefixed with
"robot_").
The time index is wrapped in struct with explicit constructor to avoid
accidentally using it instead of the camera time index in the regular
getter methods.


## How I Tested

Via the extended unit test.